### PR TITLE
fix: drawer tags creation

### DIFF
--- a/src/components/variant/ui/drawer-tags.tsx
+++ b/src/components/variant/ui/drawer-tags.tsx
@@ -1,11 +1,13 @@
 import { useRef, useState } from 'react'
 import Checkbox from 'react-three-state-checkbox'
+import { toast } from 'react-toastify'
 import classNames from 'classnames'
 import { get } from 'lodash'
 import { observer } from 'mobx-react-lite'
 
 import { useOutsideClick } from '@core/hooks/use-outside-click'
 import { t } from '@i18n'
+import datasetStore from '@store/dataset'
 import variantStore from '@store/variant'
 import { Button } from '@ui/button'
 import { Input } from '@ui/input'
@@ -46,8 +48,20 @@ const DrawerNoteModal = observer(({ close }: any) => {
   }
 
   const handleSetCustomTag = () => {
-    variantStore.updateGeneralTags(customTag)
-    setCustomTag('')
+    if (variantStore.generalTags.includes(customTag)) {
+      toast.error(t('variant.tagExists'), {
+        position: 'bottom-right',
+        autoClose: 2000,
+        hideProgressBar: true,
+        closeOnClick: true,
+        pauseOnHover: true,
+        draggable: true,
+        progress: 0,
+      })
+    } else {
+      variantStore.updateGeneralTags(customTag)
+      setCustomTag('')
+    }
   }
 
   const handleSaveTags = () => {
@@ -60,7 +74,7 @@ const DrawerNoteModal = observer(({ close }: any) => {
     })
 
     variantStore.fetchSelectedTagsAsync(params)
-
+    datasetStore.initDatasetAsync(datasetStore.datasetName)
     close()
   }
 

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -89,6 +89,7 @@ export const en = {
     tagsFor: 'Tags for',
     notes: 'Notes',
     notesFor: 'Notes for',
+    tagExists: 'Tag is already exists',
   },
   filter: {
     method: 'Filtering method',


### PR DESCRIPTION
Blocked ability to create tags with the same name (in frontend part).
Saving tags in variant drawer immediately displays on main table.