### PR TITLE
Added logic to drawer transcripts checkbox

### DIFF
--- a/src/components/variant/ui/body.tsx
+++ b/src/components/variant/ui/body.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect } from 'react'
+import { ReactElement, useEffect, useState } from 'react'
 import GridLayout from 'react-grid-layout'
 import Checkbox from 'react-three-state-checkbox'
 import cn from 'classnames'
@@ -11,6 +11,10 @@ import { t } from '@i18n'
 import variantStore from '@store/variant'
 import { Icon } from '@ui/icon'
 
+const normClass = 'norm'
+const normHitClass = 'norm hit'
+const noTrHitClass = 'no-tr-hit'
+
 const PreView = ({ content }: ReccntCommon): ReactElement => {
   return <pre className="overflow-y-hidden">{content}</pre>
 }
@@ -19,11 +23,21 @@ const TableView = ({ colhead, rows, name }: ReccntCommon): ReactElement => {
   let colheadData: string[] = []
 
   if (colhead) {
-    colheadData = [colhead && colhead[0][0]]
+    colheadData = [colhead[0][0]]
+
+    const endOfString = colheadData[0].indexOf(']')
+
+    colheadData[0] = colheadData[0].slice(0, endOfString + 1)
 
     if (name === 'view_transcripts') {
       colheadData.push(t('variant.showSelectionOnly'))
     }
+  }
+
+  const [filterSelection, setFilterSelection] = useState(normClass)
+
+  const handleSelection = (checked: boolean) => {
+    checked ? setFilterSelection(normHitClass) : setFilterSelection(normClass)
   }
 
   return (
@@ -38,7 +52,11 @@ const TableView = ({ colhead, rows, name }: ReccntCommon): ReactElement => {
                   {th}
 
                   {th === t('variant.showSelectionOnly') && (
-                    <Checkbox checked={false} className="ml-1" />
+                    <Checkbox
+                      checked={filterSelection !== normClass}
+                      className="ml-1"
+                      onChange={(e: any) => handleSelection(e.target.checked)}
+                    />
                   )}
                 </td>
               ))}
@@ -64,13 +82,18 @@ const TableView = ({ colhead, rows, name }: ReccntCommon): ReactElement => {
                   </td>
                 </Tooltip>
 
-                {row.cells.map((cell, cIndex) => (
-                  <td
-                    key={cIndex}
-                    className="py-3 pr-3 font-medium"
-                    dangerouslySetInnerHTML={{ __html: cell[0] }}
-                  />
-                ))}
+                {row.cells
+                  .filter(cell => cell[1].includes(filterSelection))
+                  .map((cell, cIndex) => (
+                    <td
+                      key={cIndex}
+                      className={cn(
+                        'py-3 pr-3 font-medium',
+                        !cell[1].includes(noTrHitClass) && 'text-white',
+                      )}
+                      dangerouslySetInnerHTML={{ __html: cell[0] }}
+                    />
+                  ))}
               </tr>
             )
           })}

--- a/src/pages/ws/ui/control-panel-preset.tsx
+++ b/src/pages/ws/ui/control-panel-preset.tsx
@@ -17,7 +17,7 @@ export const Preset = observer(
     )
 
     const onSelectAsync = async (arg: Option) => {
-      datasetStore.fetchWsListAsync(false)
+      datasetStore.fetchWsListAsync(false, arg.value)
       datasetStore.setIsLoadingTabReport(true)
       datasetStore.setActivePreset(arg.value)
       filterPresetStore.loadPresetAsync(arg.value)

--- a/src/store/dataset.ts
+++ b/src/store/dataset.ts
@@ -369,7 +369,7 @@ class DatasetStore {
     })
   }
 
-  async fetchWsListAsync(isXL?: boolean) {
+  async fetchWsListAsync(isXL?: boolean, activePreset?: string) {
     const body = new URLSearchParams({
       ds: this.datasetName,
     })
@@ -379,7 +379,7 @@ class DatasetStore {
       body.append('zone', JSON.stringify(this.zone))
     }
 
-    this.activePreset && body.append('filter', this.activePreset)
+    activePreset && body.append('filter', activePreset)
 
     const response = await fetch(getApiUrl(isXL ? `ds_list` : `ws_list`), {
       method: 'POST',

--- a/src/store/variant.ts
+++ b/src/store/variant.ts
@@ -25,12 +25,23 @@ export class VariantStore {
   }
 
   prevVariant() {
-    this.index -= 1
+    datasetStore.filteredNo.length === 0
+      ? (this.index += 1)
+      : (this.index =
+          datasetStore.filteredNo[
+            datasetStore.filteredNo.indexOf(this.index) - 1
+          ])
     this.fetchVarinatInfoAsync()
   }
 
   nextVariant() {
-    this.index += 1
+    datasetStore.filteredNo.length === 0
+      ? (this.index += 1)
+      : (this.index =
+          datasetStore.filteredNo[
+            datasetStore.filteredNo.indexOf(this.index) + 1
+          ])
+
     this.fetchVarinatInfoAsync()
   }
 
@@ -79,6 +90,8 @@ export class VariantStore {
     if (oldIndex !== index) {
       this.fetchVarinatInfoAsync()
     }
+
+    this.fetchVarinatInfoAsync()
   }
 
   setDsName(dsName: string) {
@@ -98,10 +111,19 @@ export class VariantStore {
   async fetchVarinatInfoAsync() {
     if (datasetStore.isXL) return
 
+    const details = datasetStore.wsRecords.find(
+      record => record.no === this.index,
+    )
+
     const [variantResponse, tagsResponse] = await Promise.all([
-      fetch(getApiUrl(`reccnt?ds=${this.dsName}&rec=${this.index}`), {
-        method: 'POST',
-      }),
+      fetch(
+        getApiUrl(
+          `reccnt?ds=${this.dsName}&rec=${this.index}&details=${details?.dt}`,
+        ),
+        {
+          method: 'POST',
+        },
+      ),
       fetch(getApiUrl(`ws_tags?ds=${this.dsName}&rec=${this.index}`)),
     ])
 


### PR DESCRIPTION
This logic allows user to show only selection (active) transcripts
In addition:
1. Fix problem with incorrect variants displaying after any preset has been applied (ws page)