### PR TITLE
fix(FOROME-310): drawer behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ To learn React, check out the [React documentation](https://reactjs.org/).
 ### Environment configuration
 - `REACT_APP_PROXY_AUTH` - at local development we use `src/setupProxy.js` with `http-proxy-middleware` and `auth` setting (basic auth). For fast automatic authorization you can create `.env.development.local` at root folder with following strings:
 - REACT_APP_PROXY_AUTH=login:password
-
+- REACT_APP_URL_BACKEND=

--- a/src/components/variant/ui/drawer-tags.tsx
+++ b/src/components/variant/ui/drawer-tags.tsx
@@ -8,7 +8,6 @@ import { observer } from 'mobx-react-lite'
 
 import { useOutsideClick } from '@core/hooks/use-outside-click'
 import { t } from '@i18n'
-import datasetStore from '@store/dataset'
 import variantStore from '@store/variant'
 import { Button } from '@ui/button'
 import { Input } from '@ui/input'
@@ -105,9 +104,7 @@ const DrawerTagModal = observer(({ close }: any) => {
       }
     })
 
-    datasetStore.fetchWsListAsync()
     variantStore.fetchSelectedTagsAsync(params)
-    datasetStore.fetchWsTagsAsync()
     close()
   }
 

--- a/src/components/variant/ui/header.tsx
+++ b/src/components/variant/ui/header.tsx
@@ -57,6 +57,9 @@ export const VariantHeader = observer(
 
     const handleCloseDrawer = () => {
       setVariantIndex()
+      variantStore.resetIsActiveVariant()
+      datasetStore.fetchWsListAsync()
+      datasetStore.fetchWsTagsAsync()
 
       closeHandler()
     }

--- a/src/pages/ws/ui/table.tsx
+++ b/src/pages/ws/ui/table.tsx
@@ -105,16 +105,10 @@ export const Table = observer(
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])
 
-    const getCurrentVariantIndex = () => {
-      return datasetStore.filteredNo[variantStore.choosedIndex]
-        ? variantStore.choosedIndex
-        : 0
-    }
-
     useEffect(() => {
       variantStore.isActiveVariant &&
         handleOpenVariant({
-          index: getCurrentVariantIndex(),
+          index: 0,
         })
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [])


### PR DESCRIPTION
Changed behaviour:
1. Adding tags in drawer do not trigger table updating, only drawer closing can do it now. It leads to decreasing a number of renderings.

Resolved problems:
1. Adding tags do not trigger occasional scroll in table. User will be able to see the current variant he added tag to
2. Applying filter preset or some zone filter automatically scroll table to the first variant