### PR TITLE
fix(FOROME-391): relocate refiner list tooltips

### DIFF
--- a/src/pages/filter/ui/filter-refiner-group-item.tsx
+++ b/src/pages/filter/ui/filter-refiner-group-item.tsx
@@ -7,6 +7,7 @@ import Tooltip from 'rc-tooltip'
 
 import { StatListType } from '@declarations'
 import filterStore from '@store/filter'
+import { Icon } from '@ui/icon'
 
 type Props = StatListType & {
   onChange?: (checked: boolean) => void
@@ -49,56 +50,60 @@ export const FilterRefinerGroupItem = observer(
     }
 
     return (
-      <Tooltip
-        key={group}
-        overlay={tooltip}
-        placement="bottomLeft"
-        trigger={tooltip ? ['hover'] : []}
+      <div
+        className={cn(
+          'flex items-center py-1 pr-20',
+          {
+            'bg-blue-light': isIndeterminate,
+          },
+          className,
+        )}
       >
-        <div
-          className={cn(
-            'flex items-center py-1 pr-20',
-            {
-              'bg-blue-light': isIndeterminate,
-            },
-            className,
-          )}
-        >
-          <Checkbox
-            className="cursor-pointer bg-white w-4 h-4 rounded-sm border-2 border-grey-blue"
-            checked={checked}
-            indeterminate={isIndeterminate}
-            disabled={(isFunc || isNumeric) && !checked}
-            onChange={event => onChange && onChange(event.target.checked)}
-          />
+        <Checkbox
+          className="cursor-pointer bg-white w-4 h-4 rounded-sm border-2 border-grey-blue"
+          checked={checked}
+          indeterminate={isIndeterminate}
+          disabled={(isFunc || isNumeric) && !checked}
+          onChange={event => onChange && onChange(event.target.checked)}
+        />
 
-          {isFunc && (
-            <p className="text-10 leading-10px text-green-secondary bg-green-light p-1 w-4 h-4 flex items-center ml-2 rounded-sm">
-              fn
-            </p>
-          )}
-
-          <p
-            key={name}
-            onClick={handleSelect}
-            className={cn('text-14 ml-2 cursor-pointer', {
-              'font-bold': checked,
-            })}
-          >
-            {name || title}
+        {isFunc && (
+          <p className="text-10 leading-10px text-green-secondary bg-green-light p-1 w-4 h-4 flex items-center ml-2 rounded-sm">
+            fn
           </p>
+        )}
 
-          {amount !== 0 && (
-            <span className="text-14 text-grey-blue ml-1">
-              {'('}
-              {selectedSum !== 0 && (
-                <span className="text-14 text-blue-bright">{`${selectedSum}/`}</span>
-              )}
-              {`${amount})`}
-            </span>
-          )}
-        </div>
-      </Tooltip>
+        <p
+          key={name}
+          onClick={handleSelect}
+          className={cn('text-14 ml-2 cursor-pointer', {
+            'font-bold': checked,
+          })}
+        >
+          {name || title}
+        </p>
+
+        {amount !== 0 && (
+          <span className="text-14 text-grey-blue ml-1">
+            {'('}
+            {selectedSum !== 0 && (
+              <span className="text-14 text-blue-bright">{`${selectedSum}/`}</span>
+            )}
+            {`${amount})`}
+          </span>
+        )}
+
+        {tooltip && (
+          <Tooltip
+            key={group}
+            overlay={tooltip}
+            placement="left"
+            trigger={tooltip ? ['click'] : []}
+          >
+            <Icon name="Info" className="ml-1 text-grey-blue cursor-pointer" />
+          </Tooltip>
+        )}
+      </div>
     )
   },
 )

--- a/src/ui/icon.tsx
+++ b/src/ui/icon.tsx
@@ -17,6 +17,7 @@ import File from '@icons/file'
 import Filter from '@icons/filter'
 import Folder from '@icons/folder'
 import FullScreen from '@icons/full-screen'
+import Info from '@icons/info'
 import Lines from '@icons/lines'
 import Loupe from '@icons/loupe'
 import Options from '@icons/options'
@@ -26,6 +27,7 @@ import SettingsFat from '@icons/settings-fat'
 import Sort from '@icons/sort'
 import ThreadAdd from '@icons/thread-add'
 import ThreadClose from '@icons/thread-close'
+
 interface IconItem {
   size: number
   viewBox: { w: number; h: number }
@@ -51,6 +53,7 @@ const iconItems: { [key: string]: IconItem } = {
   Filter,
   Folder,
   FullScreen,
+  Info,
   Lines,
   Loupe,
   Options,

--- a/src/ui/icons/info.tsx
+++ b/src/ui/icons/info.tsx
@@ -1,0 +1,23 @@
+import { Fragment } from 'react'
+
+const size = 16
+
+export default {
+  size,
+  viewBox: { w: size, h: size },
+  stroke: true,
+  content: (
+    <Fragment>
+      <path
+        d="M8 14C11.3137 14 14 11.3137 14 8C14 4.68629 11.3137 2 8 2C4.68629 2 2 4.68629 2 8C2 11.3137 4.68629 14 8 14Z"
+        strokeMiterlimit="10"
+      />
+      <path d="M8 5V8.5" strokeLinecap="round" strokeLinejoin="round" />
+      <path
+        d="M8 11.5C8.41421 11.5 8.75 11.1642 8.75 10.75C8.75 10.3358 8.41421 10 8 10C7.58579 10 7.25 10.3358 7.25 10.75C7.25 11.1642 7.58579 11.5 8 11.5Z"
+        strokeWidth={0}
+        fill="#9fb1c0"
+      />
+    </Fragment>
+  ),
+}


### PR DESCRIPTION
Add special icon to the right side of refiner attrs list. Only clicking on it can trigger a tooltip displaying.