### PR TITLE
refactor (FOROME-354): Added colors / button component refactoring

### DIFF
--- a/src/components/popper-table-modal.tsx
+++ b/src/components/popper-table-modal.tsx
@@ -127,8 +127,7 @@ export const PopperTableModal = observer(
         <div className="flex justify-end pb-4 px-4 mt-4">
           <Button
             text={t('general.cancel')}
-            hasBackground={false}
-            isBlackText
+            variant={'secondary'}
             onClick={handleClose}
           />
 

--- a/src/components/variant/ui/drawer-note.tsx
+++ b/src/components/variant/ui/drawer-note.tsx
@@ -18,12 +18,12 @@ const DrawerNoteButton = observer(({ refEl, onClick }: any) => {
     <Button
       refEl={refEl}
       text={variantStore.noteText ? undefined : '+ Add'}
-      className={classNames('text-white hover:bg-blue-bright', {
+      className={classNames({
         'bg-blue-bright': !!variantStore.noteText,
       })}
       size="xs"
       icon={variantStore.noteText ? <Icon name="File" /> : undefined}
-      hasBackground={false}
+      variant={'secondary-dark'}
       onClick={onClick}
       dataTestId={VariantDrawerDataCy.addNote}
     />
@@ -103,8 +103,7 @@ const DrawerNoteModal = observer(({ close }: any) => {
             <Button
               text={t('general.delete')}
               onClick={deleteNoteAsync}
-              hasBackground={false}
-              isBlackText
+              variant={'secondary'}
               className="border-red-secondary hover:text-white hover:bg-red-secondary"
             />
           )}
@@ -114,8 +113,7 @@ const DrawerNoteModal = observer(({ close }: any) => {
           <Button
             text={t('general.cancel')}
             onClick={close}
-            hasBackground={false}
-            isBlackText
+            variant={'secondary'}
             className="ml-4 hover:bg-blue-bright hover:text-white"
           />
 
@@ -123,8 +121,7 @@ const DrawerNoteModal = observer(({ close }: any) => {
             text="Save note"
             dataTestId={VariantDrawerDataCy.saveNote}
             disabled={!value || !value.trim()}
-            hasBackground={false}
-            isBlackText
+            variant={'secondary'}
             className="ml-4 hover:bg-blue-bright hover:text-white"
             onClick={handleSaveNoteAsync}
           />

--- a/src/components/variant/ui/drawer-tags.tsx
+++ b/src/components/variant/ui/drawer-tags.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react'
 import Checkbox from 'react-three-state-checkbox'
 import { toast } from 'react-toastify'
-import classNames from 'classnames'
 import get from 'lodash/get'
 import isBoolean from 'lodash/isBoolean'
 import { observer } from 'mobx-react-lite'
@@ -20,9 +19,8 @@ const DrawerTagButton = observer(({ refEl, onClick }: any) => {
     <Button
       refEl={refEl}
       text={'+ Add'}
-      className={classNames('text-white hover:bg-blue-bright')}
       size="xs"
-      hasBackground={false}
+      variant={'secondary-dark'}
       onClick={onClick}
       dataTestId={VariantDrawerDataCy.addTag}
     />
@@ -169,8 +167,7 @@ const DrawerTagModal = observer(({ close }: any) => {
             <Button
               text="Add custom tag"
               disabled={!customTag.trim() || !!error}
-              hasBackground={false}
-              isBlackText
+              variant={'secondary'}
               className="mt-2 hover:bg-blue-bright hover:text-white"
               onClick={handleSetCustomTag}
               dataTestId={VariantDrawerDataCy.addCustomTag}
@@ -183,15 +180,13 @@ const DrawerTagModal = observer(({ close }: any) => {
         <Button
           text={t('general.cancel')}
           onClick={close}
-          hasBackground={false}
-          isBlackText
+          variant={'secondary'}
           className="mr-3 ml-auto hover:bg-blue-bright hover:text-white"
         />
 
         <Button
           text="Save tags"
-          hasBackground={false}
-          isBlackText
+          variant={'secondary'}
           className="hover:bg-blue-bright hover:text-white"
           onClick={handleSaveTagsAsync}
           dataTestId={VariantDrawerDataCy.saveTags}

--- a/src/pages/error/error.tsx
+++ b/src/pages/error/error.tsx
@@ -13,8 +13,8 @@ export const ErrorPage = () => {
 
       <Button
         text={t('error.getBack')}
-        className="mt-3 hover:bg-blue-bright"
-        hasBackground={false}
+        className="mt-3"
+        variant={'secondary-dark'}
         onClick={() => history.push(Routes.Root)}
       />
     </div>

--- a/src/pages/filter/ui/compound-request.tsx
+++ b/src/pages/filter/ui/compound-request.tsx
@@ -287,17 +287,15 @@ export const CompoundRequest = observer(
             <Button
               onClick={() => handleRequestBlocksAmount('ADD')}
               text="Add"
-              hasBackground={false}
-              isBlackText
-              className={cn('hover:text-white hover:bg-blue-bright mr-4')}
+              variant={'secondary'}
+              className={cn('mr-4')}
               disabled={requestCondition.length === 5}
             />
 
             <Button
               onClick={() => handleRequestBlocksAmount('REMOVE')}
               text="Remove"
-              hasBackground={false}
-              isBlackText
+              variant={'secondary'}
               className={cn(
                 'border-red-secondary hover:text-white hover:bg-red-secondary',
               )}

--- a/src/pages/filter/ui/filter-button.tsx
+++ b/src/pages/filter/ui/filter-button.tsx
@@ -19,11 +19,8 @@ export const FilterButton = observer(
       refEl={refEl}
       size="md"
       icon={<Icon name="Arrow" className="transform -rotate-90" />}
-      hasBackground={false}
-      className={cn(
-        'text-white mt-auto ml-2 rounded-full hover:bg-blue-bright',
-        className,
-      )}
+      variant={'secondary-dark'}
+      className={cn('mt-auto ml-2', className)}
       dataTestId={DecisionTreesMenuDataCy.decisionActions}
       onClick={rest.onClick}
     />

--- a/src/pages/filter/ui/filter-control-query-builder.tsx
+++ b/src/pages/filter/ui/filter-control-query-builder.tsx
@@ -176,10 +176,8 @@ export const FilterControlQueryBuilder = observer(
             <Button
               text={t('general.cancel')}
               size="md"
-              hasBackground={false}
-              className={cn(
-                'text-white mt-auto ml-2 rounded-full hover:bg-blue-bright',
-              )}
+              variant={'secondary-dark'}
+              className={cn('mt-auto ml-2')}
               onClick={() => {
                 filterStore.setActionName()
                 setCreateTreeName('')

--- a/src/pages/filter/ui/filter-control-refiner.tsx
+++ b/src/pages/filter/ui/filter-control-refiner.tsx
@@ -150,8 +150,8 @@ export const FilterControlRefiner = observer(
             <Button
               text={t('general.cancel')}
               size="md"
-              hasBackground={false}
-              className="text-white mt-auto ml-2 rounded-full"
+              variant={'secondary-dark'}
+              className="mt-auto ml-2"
               onClick={() => {
                 setActivePreset('')
                 setCreatePresetName('')

--- a/src/pages/filter/ui/filter-control.tsx
+++ b/src/pages/filter/ui/filter-control.tsx
@@ -61,22 +61,22 @@ export const FilterControl = observer(
               {filterStore.method === FilterMethodEnum.DecisionTree && (
                 <Button
                   text="Text editor"
-                  className="ml-2 hover:bg-blue-bright"
-                  hasBackground={false}
+                  className="ml-2"
+                  variant={'secondary-dark'}
                   onClick={() => dtreeStore.openModalTextEditor()}
                 />
               )}
               <Button
                 text="Undo"
-                className="ml-2 hover:bg-blue-bright"
-                hasBackground={false}
+                className="ml-2"
+                variant={'secondary-dark'}
                 disabled={isUndoLocked}
                 onClick={() => moveActionHistory(-1)}
               />
               <Button
                 text="Redo"
-                className="ml-2 hover:bg-blue-bright"
-                hasBackground={false}
+                className="ml-2"
+                variant={'secondary-dark'}
                 disabled={isRedoLocked}
                 onClick={() => moveActionHistory(1)}
               />

--- a/src/pages/filter/ui/function-panel.tsx
+++ b/src/pages/filter/ui/function-panel.tsx
@@ -194,6 +194,7 @@ export const FunctionPanel = observer(
               <div className="flex items-center justify-between mt-5">
                 <Button
                   text={t('general.clear')}
+                  variant={'secondary'}
                   onClick={() => {
                     handleClear()
                     props.resetForm()

--- a/src/pages/filter/ui/query-builder/modal-text-editor.tsx
+++ b/src/pages/filter/ui/query-builder/modal-text-editor.tsx
@@ -175,11 +175,8 @@ export const ModalTextEditor = observer(
             text="Drop changes"
             size="md"
             onClick={handleDrop}
-            hasBackground={false}
-            className={cn(
-              'hover:bg-blue-bright hover:text-white',
-              theme === 'light' ? 'text-black' : 'text-white',
-            )}
+            variant={'secondary-dark'}
+            className={cn(theme === 'light' ? 'text-black' : 'text-white')}
           />
 
           <Button
@@ -187,9 +184,9 @@ export const ModalTextEditor = observer(
             size="md"
             disabled={!checked || hasError(error)}
             onClick={handleDone}
-            hasBackground={false}
+            variant={'secondary-dark'}
             className={cn(
-              'mx-2 hover:bg-blue-bright hover:text-white',
+              'mx-2',
               theme === 'light' ? 'text-black' : 'text-white',
             )}
           />
@@ -199,11 +196,8 @@ export const ModalTextEditor = observer(
             size="md"
             disabled={!checked || hasError(error)}
             onClick={handleSave}
-            hasBackground={false}
-            className={cn(
-              'hover:bg-blue-bright hover:text-white',
-              theme === 'light' ? 'text-black' : 'text-white',
-            )}
+            variant={'secondary-dark'}
+            className={cn(theme === 'light' ? 'text-black' : 'text-white')}
           />
         </div>
       </ModalBase>

--- a/src/pages/filter/ui/query-builder/query-builder-total-numbers.tsx
+++ b/src/pages/filter/ui/query-builder/query-builder-total-numbers.tsx
@@ -84,8 +84,8 @@ export const QueryBuilderTotalNumbers = observer(
               dataTestId={DecisionTreesResultsDataCy.viewReturnedVariants}
               onClick={() => openTableModal(true)}
               text={t('dtree.viewReturnedVariants')}
-              hasBackground={false}
-              className="ml-auto hover:bg-blue-bright"
+              variant={'secondary-dark'}
+              className="ml-auto"
             />
           )}
 
@@ -93,8 +93,8 @@ export const QueryBuilderTotalNumbers = observer(
             <Button
               onClick={() => openTableModal(false)}
               text={t('dtree.viewVariants')}
-              hasBackground={false}
-              className="ml-5 hover:bg-blue-bright"
+              variant={'secondary-dark'}
+              className="ml-5"
             />
           )}
         </div>

--- a/src/pages/filter/ui/query-builder/ui/edit-modal-buttons.tsx
+++ b/src/pages/filter/ui/query-builder/ui/edit-modal-buttons.tsx
@@ -21,8 +21,7 @@ export const EditModalButtons = observer(
       <div className="flex justify-between items-center">
         <Button
           text={t('dtree.deleteAttribute')}
-          isBlackText
-          hasBackground={false}
+          variant={'secondary'}
           className="border-red-secondary hover:text-white hover:bg-red-secondary"
           onClick={handleDeleteAttribute}
         />
@@ -30,9 +29,8 @@ export const EditModalButtons = observer(
         <div className="flex">
           <Button
             text={t('general.cancel')}
-            isBlackText
-            hasBackground={false}
-            className="mr-2 hover:bg-blue-bright hover:text-white"
+            variant={'secondary'}
+            className="mr-2"
             onClick={handleClose}
           />
 

--- a/src/pages/filter/ui/query-builder/ui/inheritance-mode-content.tsx
+++ b/src/pages/filter/ui/query-builder/ui/inheritance-mode-content.tsx
@@ -53,9 +53,8 @@ export const InheritanceModeContent = observer(
           <Button
             onClick={handleReset}
             text="Reset"
-            hasBackground={false}
-            isBlackText
-            className="h-4/5 hover:bg-blue-bright hover:text-white"
+            variant={'secondary'}
+            className="h-4/5"
           />
         </div>
 

--- a/src/pages/filter/ui/query-builder/ui/modal-edit-compound-request.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-edit-compound-request.tsx
@@ -432,17 +432,15 @@ export const ModalEditCompoundRequest = observer(
             <Button
               onClick={() => handleRequestBlocksAmount('ADD')}
               text="Add"
-              hasBackground={false}
-              isBlackText
-              className={cn('hover:text-white hover:bg-blue-bright mr-4')}
+              variant={'secondary'}
+              className={cn('mr-4')}
               disabled={requestCondition.length === 5}
             />
 
             <Button
               onClick={() => handleRequestBlocksAmount('REMOVE')}
               text="Remove"
-              hasBackground={false}
-              isBlackText
+              variant={'secondary'}
               className={cn(
                 'border-red-secondary hover:text-white hover:bg-red-secondary',
               )}

--- a/src/pages/filter/ui/query-builder/ui/modal-save-dataset.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-save-dataset.tsx
@@ -196,8 +196,7 @@ export const ModalSaveDataset = observer(() => {
         <div className="flex ml-auto mt-6">
           <Button
             text={t('general.cancel')}
-            hasBackground={false}
-            isBlackText
+            variant={'secondary'}
             className="border-grey-light hover:bg-grey-light"
             onClick={handleClose}
             dataTestId={DecisionTreesMenuDataCy.cancelAddNewDataset}
@@ -205,10 +204,9 @@ export const ModalSaveDataset = observer(() => {
 
           <Button
             text={t('dsCreation.addDataset')}
-            className="ml-4 hover:bg-blue-bright hover:text-white"
+            className="ml-4"
             disabled={!value.trim() || error.length > 0}
-            hasBackground={false}
-            isBlackText
+            variant={'secondary'}
             onClick={saveDatasetAsync}
             dataTestId={DecisionTreesMenuDataCy.addNewDataset}
           />

--- a/src/pages/filter/ui/query-builder/ui/modal-select-compound-request.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-select-compound-request.tsx
@@ -368,17 +368,15 @@ export const ModalSelectCompoundRequest = observer(
             <Button
               onClick={() => handleRequestBlocksAmount('ADD')}
               text="Add"
-              hasBackground={false}
-              isBlackText
-              className={cn('hover:text-white hover:bg-blue-bright mr-4')}
+              variant={'secondary'}
+              className={cn('mr-4')}
               disabled={requestCondition.length === 5}
             />
 
             <Button
               onClick={() => handleRequestBlocksAmount('REMOVE')}
               text="Remove"
-              hasBackground={false}
-              isBlackText
+              variant={'secondary'}
               className={cn(
                 'border-red-secondary hover:text-white hover:bg-red-secondary',
               )}

--- a/src/pages/filter/ui/query-builder/ui/select-modal-buttons.tsx
+++ b/src/pages/filter/ui/query-builder/ui/select-modal-buttons.tsx
@@ -47,9 +47,8 @@ export const SelectModalButtons = observer(
         <div className="flex">
           <Button
             text={t('general.cancel')}
-            hasBackground={false}
-            isBlackText
-            className="mr-2 hover:bg-blue-bright hover:text-white"
+            variant={'secondary'}
+            className={'mr-2'}
             onClick={() => handleClose()}
           />
           {currentGroup && currentGroup.length > 0 ? (
@@ -57,7 +56,6 @@ export const SelectModalButtons = observer(
               <Button
                 disabled={disabled}
                 text={t('dtree.replace')}
-                className="mr-2 cursor-pointer"
                 onClick={() => handleAddAttribute('REPLACE')}
               />
 
@@ -65,7 +63,6 @@ export const SelectModalButtons = observer(
                 <Button
                   disabled={disabled}
                   text={t('dtree.addByJoining')}
-                  className="cursor-pointer rounded-full"
                   onClick={handleModalJoin}
                   icon={<Icon name="Arrow" className="transform -rotate-90" />}
                 />

--- a/src/pages/filter/ui/range-panel.tsx
+++ b/src/pages/filter/ui/range-panel.tsx
@@ -131,8 +131,7 @@ export const RangePanel = observer(
 
         <div className="flex items-center justify-between mt-1">
           <Button
-            className="text-black hover:bg-blue-bright hover:text-white"
-            hasBackground={false}
+            variant={'secondary'}
             text={t('general.clear')}
             onClick={handleClear}
           />

--- a/src/pages/ws/ui/dataset-creation-button.tsx
+++ b/src/pages/ws/ui/dataset-creation-button.tsx
@@ -23,8 +23,8 @@ export const DatasetCreationButton = () => {
         <Button
           text={t('dsCreation.saveDataset')}
           size="md"
-          hasBackground={false}
-          className="w-full bg-blue-bright cursor-pointer hover:bg-blue-dark"
+          variant={'secondary-dark'}
+          className="w-full"
           onClick={handleClick}
           dataTestId={DecisionTreesMenuDataCy.saveDataset}
         />

--- a/src/pages/ws/ui/modal-notes.tsx
+++ b/src/pages/ws/ui/modal-notes.tsx
@@ -53,15 +53,15 @@ export const ModalNotes = observer(() => {
           <div className="flex items-center">
             <Button
               text={t('general.cancel')}
-              hasBackground={false}
-              className="text-black border-grey-light hover:bg-grey-light"
+              variant={'secondary-dark'}
+              className="border-grey-light hover:bg-grey-light"
               onClick={handleClose}
             />
 
             <Button
               text={t('variant.saveNote')}
-              className="ml-4 text-black hover:bg-blue-bright hover:text-white"
-              hasBackground={false}
+              className="ml-4 text-black"
+              variant={'secondary-dark'}
               onClick={handleSaveNote}
             />
           </div>

--- a/src/pages/ws/ui/table-properties-button.tsx
+++ b/src/pages/ws/ui/table-properties-button.tsx
@@ -23,8 +23,8 @@ export const TableProperiesButton = ({
     refEl={refEl}
     onClick={onClick}
     text={t('ds.customizeTable')}
-    hasBackground={false}
-    prepend={<Icon name="Settings" className="text-blue-bright" />}
+    variant={'secondary-dark'}
+    prepend={<Icon name="Settings" />}
     append={
       <Icon
         name="Arrow"

--- a/src/theme/colors.js
+++ b/src/theme/colors.js
@@ -8,6 +8,8 @@ module.exports = {
     light: '#e7f4ff',
     secondary: '#2a4567',
     medium: '#d9ecff',
+    hover: '#0089e5',
+    active: '#0068ae',
   },
   green: {
     light: '#ddf3d9',
@@ -18,6 +20,7 @@ module.exports = {
     blue: '#9fb1c0',
     light: '#e4e4e4',
     lighter: '#fafafa',
+    disabled: '#e2e7ec',
   },
   yellow: {
     bright: '#ffff00',

--- a/src/ui/button.tsx
+++ b/src/ui/button.tsx
@@ -5,8 +5,7 @@ export interface ButtonProps {
   text?: string
   size?: 'xs' | 'sm' | 'md'
   disabled?: boolean
-  hasBackground?: boolean
-  isBlackText?: boolean
+  variant?: 'primary' | 'secondary' | 'secondary-dark' | 'primary-dark'
   className?: Argument
   onClick?: () => void
   append?: ReactElement
@@ -20,8 +19,7 @@ export const Button = ({
   text,
   size = 'md',
   disabled = false,
-  hasBackground = true,
-  isBlackText,
+  variant = 'primary',
   onClick,
   className,
   append,
@@ -33,6 +31,10 @@ export const Button = ({
   let padding = ''
   const rounding = icon ? 'rounded' : 'rounded-full'
   const classNameString: string = cn(className)
+  const isPrimary = variant === 'primary'
+  const isSecondary = variant === 'secondary'
+  const isPrimaryDark = variant === 'primary-dark'
+  const isSecondaryDark = variant === 'secondary-dark'
 
   const isDefaultBackground: boolean =
     /bg-blue-bright/.test(classNameString) || !/bg-[\w-]*/.test(classNameString)
@@ -45,7 +47,7 @@ export const Button = ({
       padding = 'py-1 ' + (text ? 'px-2' : 'px-1')
       break
     case 'md':
-      padding = 'px-2 ' + (hasBackground ? 'py-2' : 'py-1.5')
+      padding = 'px-2 ' + (isPrimary || isPrimaryDark ? 'py-2' : 'py-1.5')
       break
   }
 
@@ -54,11 +56,32 @@ export const Button = ({
     padding,
     rounding,
     {
-      'text-white': !isBlackText,
-      'bg-blue-bright': !disabled && hasBackground && isDefaultBackground,
-      'border-2 border-blue-bright': !hasBackground,
+      //default primary
+      'bg-blue-bright':
+        !disabled && (isPrimary || isPrimaryDark) && isDefaultBackground,
+      'text-white': isPrimary || isSecondaryDark || isPrimaryDark,
+      //hover primary
+      'hover:bg-blue-hover': isPrimary || isPrimaryDark,
+      'active:bg-blue-active': isPrimary || isPrimaryDark,
+      //default secondary
+      'border-2 border-blue-bright': isSecondary || isSecondaryDark,
+      'text-black': isSecondary,
+      //hover secondary
+      'hover:border-blue-hover': isSecondary || isSecondaryDark,
+      'active:border-blue-active': isSecondary || isSecondaryDark,
+      //disabled general
       'cursor-not-allowed': disabled,
-      'bg-grey-light': disabled && hasBackground,
+      'text-grey-blue': disabled,
+      //disabled primary
+      'bg-grey-disabled': disabled && (isPrimary || isPrimaryDark),
+      'hover:bg-grey-disabled': disabled && (isPrimary || isPrimaryDark),
+      'active:bg-grey-disabled': disabled && (isPrimary || isPrimaryDark),
+      //disabled secondary
+      'border-grey-disabled': disabled && (isSecondary || isSecondaryDark),
+      'hover:border-grey-disabled':
+        disabled && (isSecondary || isSecondaryDark),
+      'active:border-grey-disabled':
+        disabled && (isSecondary || isSecondaryDark),
     },
     className,
   )


### PR DESCRIPTION
Changes made:
- Removed "isBackColor" and "hasBackground" props from the Button component
- Added a "variant" prop with values of 'primary' | 'secondary' | 'secondary-dark' | 'primary-dark'
- No longer need to specify a hover or whatever class name for standard buttons
- Filter panels fix: made the "clear" button to be secondary
- Added some colors to the theme file according to the [design system](https://www.figma.com/file/Y1pjb7G24vcAcwBxOJrpIg/Anfisa?node-id=3556%3A267749)