### PR TITLE
fix(FOROME-0): refiner scroll height

### DIFF
--- a/src/pages/filter/ui/query-results.tsx
+++ b/src/pages/filter/ui/query-results.tsx
@@ -25,8 +25,8 @@ export const QueryResults = observer(
 
     return (
       <div
-        className="overflow-y-auto"
-        style={{ height: 'calc(100vh - 223px)' }}
+        className="overflow-y-scroll"
+        style={{ height: 'calc(100vh - 280px)' }}
       >
         {keys.map(subGroupKey => (
           <div key={subGroupKey} className="flex flex-col">

--- a/src/pages/filter/ui/selected-group.tsx
+++ b/src/pages/filter/ui/selected-group.tsx
@@ -16,10 +16,7 @@ export const SelectedGroup = observer(
     }
 
     return (
-      <div
-        className="bg-blue-light pt-5 px-4 w-1/3 overflow-y-auto"
-        style={{ height: 'calc(100vh - 158px)' }}
-      >
+      <div className="bg-blue-light pt-5 px-4 w-1/3 overflow-y-auto">
         <SelectedGroupHeader />
 
         <div className="bg-white h-px w-full mt-4" />


### PR DESCRIPTION
Refiner blocks (query-selected and query-results) scroll height was not enough to show some attributes lists (for example Chromosome)