### PR TITLE
feat: added session store manager and provider

### DIFF
--- a/src/components/session-store-data-provider.tsx
+++ b/src/components/session-store-data-provider.tsx
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react'
+
+import { SessionStoreManager } from '../core/session-store-manager'
+
+export interface ISessionStoreDataProviderProps<T = any> {
+  storeKey: string
+  values: T
+  storePrefix?: string
+}
+
+export const SessionStoreDataProvider = <T,>({
+  children,
+  storeKey,
+  values,
+  storePrefix,
+}: React.PropsWithChildren<ISessionStoreDataProviderProps<T>>): JSX.Element => {
+  useEffect(() => {
+    SessionStoreManager.write(storeKey, values, storePrefix)
+  }, [storeKey, values, storePrefix])
+
+  return children as JSX.Element
+}

--- a/src/core/session-store-manager.ts
+++ b/src/core/session-store-manager.ts
@@ -1,0 +1,50 @@
+/* eslint-disable unicorn/no-useless-undefined */
+export class SessionStoreManager {
+  public static read<T = any>(key: string, prefix?: string) {
+    if (prefix) {
+      const value = sessionStorage.getItem(prefix)
+
+      if (!value) return undefined
+
+      return (JSON.parse(value) || {})[key] as T
+    } else {
+      const value = sessionStorage.getItem(key)
+
+      if (!value) return undefined
+
+      return JSON.parse(value) as T
+    }
+  }
+
+  public static write(key: string, data: any, prefix?: string) {
+    if (prefix) {
+      const savedData = this.read(prefix)
+
+      if (savedData) {
+        savedData[key] = data
+
+        return sessionStorage.setItem(prefix, JSON.stringify(savedData))
+      } else {
+        return sessionStorage.setItem(prefix, JSON.stringify({ [key]: data }))
+      }
+    }
+
+    return sessionStorage.setItem(key, JSON.stringify(data))
+  }
+
+  public static delete(key: string, prefix?: string) {
+    if (prefix) {
+      const savedData = this.read(prefix)
+
+      if (savedData) {
+        delete savedData[key]
+
+        return this.write(prefix, savedData)
+      } else {
+        return undefined
+      }
+    }
+
+    return sessionStorage.removeItem(key)
+  }
+}


### PR DESCRIPTION
Terms:
**storeKey**: Key which is going to be a session storage key
_Example_
`[storeKey]: "{
    "foo": 2, 
    "bar": "Jonh Doe"
}"`
**values**: Values that are going to be stored in session storage. A specific type can be provided via TS generic.
**storePrefix**: A special key which aggregates other keys inside of it.
_Example_
`[storePrefix]: "{
        [someKey]: {
            "foo": 2, 
            "bar": "Jonh Doe"
        },
        [anotherKey]: {
            "foo": 2, 
            "bar": "Jonh Doe"
        }
}"`