### PR TITLE
feat(FOROME-435): add validation for refiner gene-region

### DIFF
--- a/src/pages/filter/ui/compound-request.tsx
+++ b/src/pages/filter/ui/compound-request.tsx
@@ -19,8 +19,9 @@ import { getResetRequestData } from '@utils/getResetRequestData'
 import { getResetType } from '@utils/getResetType'
 import { getSortedArray } from '@utils/getSortedArray'
 import { AllNotModalMods } from './query-builder/ui/all-not-modal-mods'
-import { EditModalVariants } from './query-builder/ui/edit-modal-variants'
+import { DisabledVariantsAmount } from './query-builder/ui/disabled-variants-amount'
 import { selectOptions } from './query-builder/ui/modal-select-custom-inheritance-mode'
+
 export interface ICompoundRequestFormValues {
   requestCondition: TRequestCondition[]
   reset: string
@@ -348,7 +349,7 @@ export const CompoundRequest = observer(
           </div>
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount variants={variants} disabled={true} />
       </React.Fragment>
     )
   },

--- a/src/pages/filter/ui/function-panel.tsx
+++ b/src/pages/filter/ui/function-panel.tsx
@@ -53,10 +53,8 @@ export const FunctionPanel = (): ReactElement => {
   const Component: FunctionComponent<Record<string, any>> =
     functionsMap[selectedFilter.name]
 
-  const isSubmitDisabled = !!filterStore.error
-
   const onSubmitAsync = async (values: any) => {
-    if (isSubmitDisabled) return
+    if (filterStore.error) return
 
     if (isArray(values.variants) && values.variants.length === 0) {
       toast.warning(t('filter.chooseProblemGroup'), {
@@ -172,6 +170,8 @@ export const FunctionPanel = (): ReactElement => {
       groupItemName: selectedFilter.name,
       variant: [selectedFilter.name, 0],
     })
+
+    filterStore.resetStatFuncData()
   }
 
   if (!Component) {
@@ -204,7 +204,7 @@ export const FunctionPanel = (): ReactElement => {
               <Button
                 text={t('general.add')}
                 onClick={props.submitForm}
-                disabled={isSubmitDisabled}
+                disabled={!!filterStore.error}
               />
             </div>
           </div>

--- a/src/pages/filter/ui/gene-region.tsx
+++ b/src/pages/filter/ui/gene-region.tsx
@@ -1,46 +1,93 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { Form, FormikProps } from 'formik'
+import { observer } from 'mobx-react-lite'
 
 import { FuncStepTypesEnum } from '@core/enum/func-step-types-enum'
+import { t } from '@i18n'
 import filterStore from '@store/filter'
 import { Input } from '@ui//input'
+import { validateLocusCondition } from '@utils/validateLocusCondition'
+import { DisabledVariantsAmount } from './query-builder/ui/disabled-variants-amount'
+
 export interface IGeneRegionFormValues {
   locus: string
 }
 
-export const GeneRegion = ({
-  values: { locus },
-  setFieldValue,
-}: FormikProps<IGeneRegionFormValues>) => {
-  const cachedValues = filterStore.readFilterCondition<IGeneRegionFormValues>(
-    FuncStepTypesEnum.GeneRegion,
-  )
-
-  const locusValue = cachedValues?.locus || locus
-
-  useEffect(() => {
-    filterStore.setFilterCondition<IGeneRegionFormValues>(
+export const GeneRegion = observer(
+  ({
+    values: { locus },
+    setFieldValue,
+  }: FormikProps<IGeneRegionFormValues>) => {
+    const cachedValues = filterStore.readFilterCondition<IGeneRegionFormValues>(
       FuncStepTypesEnum.GeneRegion,
-      {
-        locus,
-      },
     )
-  }, [locus])
 
-  return (
-    <Form>
-      <div className="mt-4">
-        <span className="text-14 leading-16px text-grey-blue font-bold">
-          Locus
-        </span>
+    const locusValue = cachedValues?.locus || ''
+    const { variants } = filterStore.statFuncData
 
-        <Input
-          value={locusValue}
-          onChange={e => {
-            setFieldValue('locus', e.target.value)
-          }}
-        />
-      </div>
-    </Form>
-  )
-}
+    const [isErrorVisible, setIsErrorVisible] = useState(false)
+
+    const validateValue = (value: string) => {
+      validateLocusCondition({ value, setIsErrorVisible })
+    }
+
+    useEffect(() => {
+      isErrorVisible
+        ? filterStore.setError('out of choice')
+        : filterStore.setError('')
+    }, [isErrorVisible])
+
+    useEffect(() => {
+      if (!locusValue) {
+        filterStore.setError('out of choice')
+      }
+
+      const params = `{"locus":"${locusValue}"}`
+
+      filterStore.fetchStatFuncAsync('GeneRegion', params)
+
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
+
+    useEffect(() => {
+      filterStore.setFilterCondition<IGeneRegionFormValues>(
+        FuncStepTypesEnum.GeneRegion,
+        {
+          locus,
+        },
+      )
+    }, [locus])
+
+    return (
+      <Form>
+        <div className="mt-4">
+          <span className="text-14 leading-16px text-grey-blue font-bold">
+            Locus
+          </span>
+
+          <div className="relative flex">
+            <Input
+              value={locusValue}
+              onChange={e => {
+                setFieldValue('locus', e.target.value)
+                validateValue(e.target.value)
+              }}
+            />
+
+            {isErrorVisible && (
+              <div className="absolute -bottom-4 flex items-center mt-1 h-3 text-10 text-red-secondary">
+                {t('dtree.chromosomeNameIsNotCorrect')}
+              </div>
+            )}
+          </div>
+
+          <DisabledVariantsAmount
+            variants={variants}
+            disabled={true}
+            isErrorVisible={isErrorVisible}
+          />
+        </div>
+      </Form>
+    )
+  },
+)

--- a/src/pages/filter/ui/query-builder/ui/custom-inheritance-mode-content.tsx
+++ b/src/pages/filter/ui/query-builder/ui/custom-inheritance-mode-content.tsx
@@ -8,7 +8,7 @@ import filterStore from '@store/filter'
 import { Select } from '@ui/select'
 import { resetOptions } from '../../compound-request'
 import { AllNotModalMods } from './all-not-modal-mods'
-import { EditModalVariants } from './edit-modal-variants'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 import { selectOptions } from './modal-select-custom-inheritance-mode'
 
 interface IProps {
@@ -65,7 +65,7 @@ export const CustomInheritanceModeContent = observer(
           <AllNotModalMods />
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount variants={variants} disabled={true} />
       </Fragment>
     )
   },

--- a/src/pages/filter/ui/query-builder/ui/disabled-variants-amount.tsx
+++ b/src/pages/filter/ui/query-builder/ui/disabled-variants-amount.tsx
@@ -7,16 +7,17 @@ import dtreeStore from '@store/dtree'
 interface IProps {
   variants: any[]
   disabled: boolean
+  isErrorVisible?: boolean
   handleCheckGroupItem?: (event: any, variant: string) => void
   inheritanceMode?: boolean
 }
 
-export const EditModalVariants = observer(
-  ({ variants, disabled, handleCheckGroupItem }: IProps) => (
-    <div className="flex-1 my-4 text-14">
-      {variants?.length > 0 ? (
+export const DisabledVariantsAmount = observer(
+  ({ variants, disabled, isErrorVisible, handleCheckGroupItem }: IProps) => (
+    <div className="my-5 text-14">
+      {variants?.length > 0 && !isErrorVisible ? (
         variants.map((variant: any) => (
-          <div key={variant} className="flex items-center mb-2">
+          <div key={variant} className="flex items-center">
             {disabled ? (
               <Checkbox
                 checked={true}

--- a/src/pages/filter/ui/query-builder/ui/gene-region-content.tsx
+++ b/src/pages/filter/ui/query-builder/ui/gene-region-content.tsx
@@ -4,7 +4,7 @@ import { observer } from 'mobx-react-lite'
 import { t } from '@i18n'
 import { Input } from '@ui/input'
 import { AllNotModalMods } from './all-not-modal-mods'
-import { EditModalVariants } from './edit-modal-variants'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 
 interface IProps {
   locusCondition: string
@@ -25,10 +25,10 @@ export const GeneRegionContent = observer(
     return (
       <Fragment>
         <div className="flex justify-between w-full mt-4 text-14">
-          <div className="flex h-9">
+          <div className="flex">
             <span>{t('dtree.locus')}</span>
 
-            <div className="relative flex h-9 ml-2">
+            <div className="relative flex ml-2">
               <Input
                 value={locusCondition}
                 onChange={(e: any) => {
@@ -39,7 +39,7 @@ export const GeneRegionContent = observer(
               />
 
               {isErrorVisible && (
-                <div className="absolute bottom-0 flex items-center h-3 text-10 text-red-secondary">
+                <div className="absolute -bottom-3 flex items-center mt-1 h-3 text-10 text-red-secondary">
                   {t('dtree.chromosomeNameIsNotCorrect')}
                 </div>
               )}
@@ -49,7 +49,11 @@ export const GeneRegionContent = observer(
           <AllNotModalMods />
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount
+          variants={variants}
+          disabled={true}
+          isErrorVisible={isErrorVisible}
+        />
       </Fragment>
     )
   },

--- a/src/pages/filter/ui/query-builder/ui/inheritance-mode-content.tsx
+++ b/src/pages/filter/ui/query-builder/ui/inheritance-mode-content.tsx
@@ -6,7 +6,7 @@ import { StatListType } from '@declarations'
 import { t } from '@i18n'
 import dtreeStore from '@store/dtree'
 import { Button } from '@ui/button'
-import { EditModalVariants } from './edit-modal-variants'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 import { ModsDivider } from './mods-divider'
 
 interface IProps {
@@ -82,7 +82,7 @@ export const InheritanceModeContent = observer(
           </div>
         </div>
 
-        <EditModalVariants
+        <DisabledVariantsAmount
           variants={variants}
           disabled={false}
           handleCheckGroupItem={handleCheckGroupItem}

--- a/src/pages/filter/ui/query-builder/ui/modal-edit-compound-het.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-edit-compound-het.tsx
@@ -6,8 +6,8 @@ import dtreeStore from '@store/dtree'
 import { changeFunctionalStep } from '@utils/changeAttribute/changeFunctionalStep'
 import { AllNotModalMods } from './all-not-modal-mods'
 import { ApproxStateModalMods } from './approx-state-modal-mods'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 import { EditModalButtons } from './edit-modal-buttons'
-import { EditModalVariants } from './edit-modal-variants'
 import { HeaderModal } from './header-modal'
 import { ModalBase } from './modal-base'
 
@@ -179,7 +179,7 @@ export const ModalEditCompoundHet = observer(
           <AllNotModalMods />
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount variants={variants} disabled={true} />
 
         <EditModalButtons
           handleClose={handleClose}

--- a/src/pages/filter/ui/query-builder/ui/modal-edit-compound-request.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-edit-compound-request.tsx
@@ -17,8 +17,8 @@ import { getSortedArray } from '@utils/getSortedArray'
 import { resetOptions } from '../../compound-request'
 import { AllNotModalMods } from './all-not-modal-mods'
 import { ApproxStateModalMods } from './approx-state-modal-mods'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 import { EditModalButtons } from './edit-modal-buttons'
-import { EditModalVariants } from './edit-modal-variants'
 import { HeaderModal } from './header-modal'
 import { ModalBase } from './modal-base'
 import { IParams } from './modal-edit-compound-het'
@@ -461,7 +461,7 @@ export const ModalEditCompoundRequest = observer(
           </div>
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount variants={variants} disabled={true} />
 
         <EditModalButtons
           handleClose={handleClose}

--- a/src/pages/filter/ui/query-builder/ui/modal-edit-gene-region.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-edit-gene-region.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react-lite'
 
 import dtreeStore from '@store/dtree'
 import { changeFunctionalStep } from '@utils/changeAttribute/changeFunctionalStep'
+import { validateLocusCondition } from '@utils/validateLocusCondition'
 import { EditModalButtons } from './edit-modal-buttons'
 import { GeneRegionContent } from './gene-region-content'
 import { HeaderModal } from './header-modal'
@@ -38,33 +39,12 @@ export const ModalEditGeneRegion = observer(
     }
 
     const validateValue = (value: string) => {
-      let numberValue = value[3]
-      let lastIndexOfName = 3
-
-      if (+value[4] && value.length > 4) numberValue = value.slice(3, 5)
-
-      if (numberValue) lastIndexOfName = 2 + numberValue.length
-
-      if (
-        value.slice(0, 3) !== 'chr' ||
-        !+numberValue ||
-        +numberValue > 23 ||
-        value[lastIndexOfName + 1] !== ':' ||
-        (!+value.slice(lastIndexOfName + 2) &&
-          value.slice(lastIndexOfName + 2) !== '')
-      ) {
-        setIsErrorVisible(true)
-      } else {
-        setIsErrorVisible(false)
-
-        const indexForApi = dtreeStore.getStepIndexForApi(currentStepIndex)
-
-        const params = `{"locus":"${value}"}`
-
-        dtreeStore.setCurrentStepIndexForApi(indexForApi)
-
-        dtreeStore.fetchStatFuncAsync(groupName, params)
-      }
+      validateLocusCondition({
+        value,
+        setIsErrorVisible,
+        groupName,
+        currentStepIndex,
+      })
     }
 
     useEffect(() => {

--- a/src/pages/filter/ui/query-builder/ui/modal-select-compound-het.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-select-compound-het.tsx
@@ -6,7 +6,7 @@ import dtreeStore from '@store/dtree'
 import { addAttributeToStep } from '@utils/addAttributeToStep'
 import { AllNotModalMods } from './all-not-modal-mods'
 import { ApproxStateModalMods } from './approx-state-modal-mods'
-import { EditModalVariants } from './edit-modal-variants'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 import { HeaderModal } from './header-modal'
 import { ModalBase } from './modal-base'
 import { IParams } from './modal-edit-compound-het'
@@ -148,7 +148,7 @@ export const ModalSelectCompoundHet = observer(
           <AllNotModalMods />
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount variants={variants} disabled={true} />
 
         <SelectModalButtons
           handleClose={handleClose}

--- a/src/pages/filter/ui/query-builder/ui/modal-select-compound-request.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-select-compound-request.tsx
@@ -18,7 +18,7 @@ import { getSortedArray } from '@utils/getSortedArray'
 import { resetOptions } from '../../compound-request'
 import { AllNotModalMods } from './all-not-modal-mods'
 import { ApproxStateModalMods } from './approx-state-modal-mods'
-import { EditModalVariants } from './edit-modal-variants'
+import { DisabledVariantsAmount } from './disabled-variants-amount'
 import { HeaderModal } from './header-modal'
 import { ModalBase } from './modal-base'
 import { IParams } from './modal-edit-compound-het'
@@ -397,7 +397,7 @@ export const ModalSelectCompoundRequest = observer(
           </div>
         </div>
 
-        <EditModalVariants variants={variants} disabled={true} />
+        <DisabledVariantsAmount variants={variants} disabled={true} />
 
         <SelectModalButtons
           handleClose={handleClose}

--- a/src/pages/filter/ui/query-builder/ui/modal-select-gene-region.tsx
+++ b/src/pages/filter/ui/query-builder/ui/modal-select-gene-region.tsx
@@ -4,6 +4,7 @@ import { observer } from 'mobx-react-lite'
 import { ActionType } from '@declarations'
 import dtreeStore from '@store/dtree'
 import { addAttributeToStep } from '@utils/addAttributeToStep'
+import { validateLocusCondition } from '@utils/validateLocusCondition'
 import { GeneRegionContent } from './gene-region-content'
 import { HeaderModal } from './header-modal'
 import { ModalBase } from './modal-base'
@@ -34,33 +35,12 @@ export const ModalSelectGeneRegion = observer(
     }
 
     const validateValue = (value: string) => {
-      let numberValue = value[3]
-      let lastIndexOfName = 3
-
-      if (+value[4] && value.length > 4) numberValue = value.slice(3, 5)
-
-      if (numberValue) lastIndexOfName = 2 + numberValue.length
-
-      if (
-        value.slice(0, 3) !== 'chr' ||
-        !+numberValue ||
-        +numberValue > 23 ||
-        value[lastIndexOfName + 1] !== ':' ||
-        (!+value.slice(lastIndexOfName + 2) &&
-          value.slice(lastIndexOfName + 2) !== '')
-      ) {
-        setIsErrorVisible(true)
-      } else {
-        setIsErrorVisible(false)
-
-        const indexForApi = dtreeStore.getStepIndexForApi(currentStepIndex)
-
-        const params = `{"locus":"${value}"}`
-
-        dtreeStore.setCurrentStepIndexForApi(indexForApi)
-
-        dtreeStore.fetchStatFuncAsync(groupName, params)
-      }
+      validateLocusCondition({
+        value,
+        setIsErrorVisible,
+        groupName,
+        currentStepIndex,
+      })
     }
 
     const handleClose = () => {

--- a/src/store/filter.ts
+++ b/src/store/filter.ts
@@ -173,6 +173,10 @@ class FilterStore {
     this.selectedFilters = {}
   }
 
+  resetStatFuncData() {
+    this.statFuncData = []
+  }
+
   setSelectedFilters(filters: SelectedFiltersType) {
     this.selectedFilters = JSON.parse(JSON.stringify(filters))
   }

--- a/src/utils/validateLocusCondition.ts
+++ b/src/utils/validateLocusCondition.ts
@@ -1,0 +1,51 @@
+import { FuncStepTypesEnum } from '@core/enum/func-step-types-enum'
+import dtreeStore from '@store/dtree'
+import filterStore from '@store/filter'
+
+interface IValidateLocusConditionProps {
+  value: string
+  setIsErrorVisible: (arg: boolean) => void
+  groupName?: string
+  currentStepIndex?: number
+}
+
+export const validateLocusCondition = ({
+  value,
+  setIsErrorVisible,
+  groupName,
+  currentStepIndex,
+}: IValidateLocusConditionProps): void => {
+  let numberValue = value[3]
+  let lastIndexOfName = 3
+
+  if (+value[4] && value.length > 4) numberValue = value.slice(3, 5)
+
+  if (numberValue) lastIndexOfName = 2 + numberValue.length
+
+  if (
+    value.slice(0, 3) !== 'chr' ||
+    !+numberValue ||
+    +numberValue > 23 ||
+    value[lastIndexOfName + 1] !== ':' ||
+    (!+value.slice(lastIndexOfName + 2) &&
+      value.slice(lastIndexOfName + 2) !== '')
+  ) {
+    setIsErrorVisible(true)
+    filterStore.setError('out of choice')
+  } else {
+    setIsErrorVisible(false)
+    filterStore.setError('')
+
+    const params = `{"locus":"${value}"}`
+
+    if ((currentStepIndex || currentStepIndex === 0) && groupName) {
+      const indexForApi = dtreeStore.getStepIndexForApi(currentStepIndex)
+
+      dtreeStore.setCurrentStepIndexForApi(indexForApi)
+
+      dtreeStore.fetchStatFuncAsync(groupName, params)
+    } else {
+      filterStore.fetchStatFuncAsync(FuncStepTypesEnum.GeneRegion, params)
+    }
+  }
+}


### PR DESCRIPTION
1. Added validation for "GeneRegion" attribute in filter-refiner
2. Took out validation function for every "GeneRegion" attribute into separate util
3. Small fix with "GeneRegion" error feedback behaviour
4. Changed component name from "EditModalVariants" to "DisabledVariantsAmount"
