### PR TITLE
fix(FOROME-511): preset loading

### DIFF
--- a/src/pages/filter/ui/filter-control-refiner.tsx
+++ b/src/pages/filter/ui/filter-control-refiner.tsx
@@ -41,10 +41,14 @@ export const FilterControlRefiner = observer(
 
     const handleClick = () => {
       if (filterStore.actionName === ActionFilterEnum.Load) {
-        presetStore.loadPresetAsync(activePreset, 'refiner')
         datasetStore.setActivePreset(activePreset)
+
+        if (datasetStore.prevPreset !== datasetStore.activePreset) {
+          presetStore.loadPresetAsync(activePreset, 'refiner')
+          datasetStore.fetchWsListAsync()
+        }
+
         filterStore.resetActionName()
-        datasetStore.fetchWsListAsync()
       }
 
       if (filterStore.actionName === ActionFilterEnum.Delete) {

--- a/src/pages/ws/ui/control-panel-preset.tsx
+++ b/src/pages/ws/ui/control-panel-preset.tsx
@@ -18,14 +18,17 @@ export const Preset = observer(
     )
 
     const onSelectAsync = async (arg: Option, reset?: string) => {
-      filterPresetStore.loadPresetAsync(arg.value, 'ws')
       datasetStore.setActivePreset(arg.value)
 
-      datasetStore.fetchWsListAsync(false, 'reset')
-      datasetStore.setIsLoadingTabReport(true)
+      if (datasetStore.prevPreset !== datasetStore.activePreset) {
+        filterPresetStore.loadPresetAsync(arg.value, 'ws')
 
-      reset && datasetStore.resetActivePreset()
-      reset && datasetStore.resetHasPreset()
+        datasetStore.fetchWsListAsync(false, 'reset')
+        datasetStore.setIsLoadingTabReport(true)
+
+        reset && datasetStore.resetActivePreset()
+        reset && datasetStore.resetHasPreset()
+      }
     }
 
     return (

--- a/src/store/dataset.ts
+++ b/src/store/dataset.ts
@@ -445,10 +445,8 @@ class DatasetStore {
       body.append('zone', JSON.stringify(this.zone))
     }
 
-    if (!this.prevPreset || this.prevPreset !== this.activePreset) {
-      body.append('filter', this.activePreset)
-      this.prevPreset = this.activePreset
-    }
+    this.prevPreset = this.activePreset
+    body.append('filter', this.activePreset)
 
     const response = await fetch(getApiUrl(isXL ? `ds_list` : `ws_list`), {
       method: 'POST',


### PR DESCRIPTION
1. Fixed problem with loading presets on main-table
2. If user chose the same preset in main-table/filter-refiner the request will be ignored