### PR TITLE
fix(FOROME-00): main-table-loading

### DIFF
--- a/src/pages/ws/page.tsx
+++ b/src/pages/ws/page.tsx
@@ -47,17 +47,24 @@ const WSPage = observer(
 
     const { variant, refiner } = query
 
+    const hasConditionsInSearchParamsOnly =
+      refiner.length > 0 && datasetStore.conditions.length === 0
+
     Number.isInteger(variant) && variantStore.setIndex(variant as number)
 
     useEffect(() => {
-      const conditions: Condition[] = (refiner as string[]).map((c: string) => {
-        const item: string[] = c!.split(',')
-        const [name, group, symbol, value] = item
+      if (hasConditionsInSearchParamsOnly) {
+        const conditions: Condition[] = (refiner as string[]).map(
+          (c: string) => {
+            const item: string[] = c!.split(',')
+            const [name, group, symbol, value] = item
 
-        return [name, group, symbol, [value]]
-      })
+            return [name, group, symbol, [value]]
+          },
+        )
 
-      datasetStore.setConditionsAsync(conditions)
+        datasetStore.setConditionsAsync(conditions)
+      }
 
       const initAsync = async () => {
         const dsName = params.get('ds') || ''

--- a/src/store/dataset.ts
+++ b/src/store/dataset.ts
@@ -146,19 +146,19 @@ class DatasetStore {
     if (!conditions[0]) {
       this.conditions = []
       await this.fetchDsStatAsync()
+    } else {
+      const groupCondtionsIndex = this.conditions.findIndex(
+        (item: any) => item[1] === conditions[0][1],
+      )
+
+      if (groupCondtionsIndex !== -1) {
+        this.conditions.splice(groupCondtionsIndex, 1)
+      }
+
+      this.conditions = this.conditions.concat(conditions)
+
+      await this.fetchDsStatAsync()
     }
-
-    const groupCondtionsIndex = this.conditions.findIndex(
-      (item: any) => item[1] === conditions[0][1],
-    )
-
-    if (groupCondtionsIndex !== -1) {
-      this.conditions.splice(groupCondtionsIndex, 1)
-    }
-
-    this.conditions = this.conditions.concat(conditions)
-
-    await this.fetchDsStatAsync()
 
     return Array.from({ length: this.statAmount[0] })
   }


### PR DESCRIPTION
1. Got back main-table fast loading
2. Fixed export problem 
 *export problem scenario:
1) Given Main Table for the "PGP3140_wgs_panel_hl" dataset is open
2) When the user chooses the "⏚SEQaBOO_Hearing_Loss_v_5" preset
3) and the user clicks the "Edit filters" button
4) and clicks the "Callers" attribute"
5) and chooses the "BGM_CMPD_HET" value
6) and clicks the "Add" button
7) and clicks the "Apply" button
8) and clicks Export - Excel
