### PR TITLE
feat(FOROME-353): add modals for table samples

### DIFF
--- a/.github/workflows/sandbox.yaml
+++ b/.github/workflows/sandbox.yaml
@@ -10,7 +10,7 @@ on:
       - 'FOROME-*'
       - '!main'
       - '!develop'
-    tags: [ stage ]
+    tags: [ dev ]
     
 jobs:
   build:

--- a/src/pages/ws/ui/cell-sample.tsx
+++ b/src/pages/ws/ui/cell-sample.tsx
@@ -29,16 +29,6 @@ export const CellSample = ({
   const shouldTooltipBeVisible =
     isTooltipVisible && isTruncated && samplesAmount < 4
 
-  const ModalTooltipContent = () => (
-    <div className="flex flex-wrap justify-start">
-      <div>{sample}</div>
-
-      <div className="w-full">{genotype}</div>
-
-      <div>{quality}</div>
-    </div>
-  )
-
   return (
     <div
       onMouseEnter={showTooltip}
@@ -58,7 +48,13 @@ export const CellSample = ({
 
       {shouldTooltipBeVisible && (
         <ModalTooltip>
-          <ModalTooltipContent />
+          <div className="flex flex-wrap justify-start">
+            <div>{sample}</div>
+
+            <div className="w-full">{genotype}</div>
+
+            <div>{quality}</div>
+          </div>
         </ModalTooltip>
       )}
     </div>

--- a/src/pages/ws/ui/cell-sample.tsx
+++ b/src/pages/ws/ui/cell-sample.tsx
@@ -1,0 +1,66 @@
+import { ReactElement } from 'react'
+import cn from 'classnames'
+
+import { useToggle } from '@core/hooks/use-toggle'
+import filterZone from '@store/filterZone'
+import { IQualities } from './cell-samples'
+import { ModalTooltip } from './modal-tooltip'
+
+interface ICellSamplesProps {
+  qualities: IQualities
+  sample: string
+  samplesAmount: number
+  index: number
+}
+
+export const CellSample = ({
+  qualities,
+  sample,
+  samplesAmount,
+  index,
+}: ICellSamplesProps): ReactElement => {
+  const genotype: string = qualities[sample].genotype
+  const quality: number = qualities[sample].g_quality
+
+  const [isTooltipVisible, showTooltip, hideTooltip] = useToggle()
+
+  const isTruncated = qualities[sample].genotype.length > 10
+
+  const shouldTooltipBeVisible =
+    isTooltipVisible && isTruncated && samplesAmount < 4
+
+  const ModalTooltipContent = () => (
+    <div className="flex flex-wrap justify-start">
+      <div>{sample}</div>
+
+      <div className="w-full">{genotype}</div>
+
+      <div>{quality}</div>
+    </div>
+  )
+
+  return (
+    <div
+      onMouseEnter={showTooltip}
+      onMouseLeave={hideTooltip}
+      key={sample}
+      className={cn('relative w-1/3 px-4 py-4', {
+        'bg-orange-light': filterZone.isFather && index === 2,
+        'bg-yellow-light': filterZone.isMother && index === 1,
+        'bg-purple-light': filterZone.isProband && index === 0,
+      })}
+    >
+      <div>{sample}</div>
+
+      <div className="truncate">{genotype}</div>
+
+      <div>{quality}</div>
+
+      {shouldTooltipBeVisible && (
+        <ModalTooltip>
+          <ModalTooltipContent />
+        </ModalTooltip>
+      )}
+    </div>
+  )
+}

--- a/src/pages/ws/ui/cell-samples.tsx
+++ b/src/pages/ws/ui/cell-samples.tsx
@@ -1,31 +1,32 @@
 import { ReactElement } from 'react'
-import cn from 'classnames'
 import get from 'lodash/get'
 import { observer } from 'mobx-react-lite'
 
-import filterZone from '@store/filterZone'
 import { CellI } from './cell-interfaces'
+import { CellSample } from './cell-sample'
+
+export interface IQualities {
+  [key: string]: {
+    genotype: string
+    g_quality: number
+  }
+}
 
 export const CellSamples = observer(({ cell }: CellI): ReactElement => {
-  const qualities = get(cell, 'value', {}) as any
+  const qualities = get(cell, 'value', {}) as IQualities
+
+  const samplesAmount: number = Object.keys(cell.value).length
 
   return (
     <div className="h-full flex text-10">
       {Object.keys(qualities).map((item, index) => (
-        <div
-          key={item}
-          className={cn('w-1/3 px-4 py-4', {
-            'bg-orange-light': filterZone.isFather && index === 2,
-            'bg-yellow-light': filterZone.isMother && index === 1,
-            'bg-purple-light': filterZone.isProband && index === 0,
-          })}
-        >
-          <div>{item}</div>
-
-          <div className="truncate">{qualities[item].genotype}</div>
-
-          <div>{qualities[item].g_quality}</div>
-        </div>
+        <CellSample
+          key={item + index}
+          qualities={qualities}
+          sample={item}
+          samplesAmount={samplesAmount}
+          index={index}
+        />
       ))}
     </div>
   )

--- a/src/pages/ws/ui/modal-tooltip.tsx
+++ b/src/pages/ws/ui/modal-tooltip.tsx
@@ -1,12 +1,8 @@
-import { ReactElement } from 'react'
-
-interface IModalTooltipProps {
-  children: ReactElement
-}
+import { PropsWithChildren, ReactElement, ReactNode } from 'react'
 
 export const ModalTooltip = ({
   children,
-}: IModalTooltipProps): ReactElement => (
+}: PropsWithChildren<unknown>): ReactElement => (
   <div className="absolute flex flex-wrap items-center h-full px-2 top-0 z-50 shadow-dark rounded-md bg-white">
     {children}
   </div>

--- a/src/pages/ws/ui/modal-tooltip.tsx
+++ b/src/pages/ws/ui/modal-tooltip.tsx
@@ -1,0 +1,13 @@
+import { ReactElement } from 'react'
+
+interface IModalTooltipProps {
+  children: ReactElement
+}
+
+export const ModalTooltip = ({
+  children,
+}: IModalTooltipProps): ReactElement => (
+  <div className="absolute flex flex-wrap items-center h-full px-2 top-0 z-50 shadow-dark rounded-md bg-white">
+    {children}
+  </div>
+)

--- a/src/pages/ws/ui/table/table.tsx
+++ b/src/pages/ws/ui/table/table.tsx
@@ -229,7 +229,7 @@ export const Table = observer(({ columns, data }: Props): ReactElement => {
                 <div
                   {...cell.getCellProps()}
                   key={Math.random()}
-                  className={cn('td overflow-hidden', {
+                  className={cn('td ', {
                     'py-1':
                       cell.column.Header !== tableColumnMap.samples &&
                       columnsStore.viewType === ViewTypeEnum.Compact,
@@ -240,13 +240,15 @@ export const Table = observer(({ columns, data }: Props): ReactElement => {
                       cell.column.Header === tableColumnMap.samples &&
                       columnsStore.viewType !== ViewTypeEnum.Compact,
                     'px-4': cell.column.Header !== tableColumnMap.samples,
+                    'overflow-hidden': !isSampleColumn,
                   })}
                 >
                   {isSampleColumn ? (
                     <div onClick={stopPropagation}>
                       <ScrollContainer
                         style={{
-                          cursor: `${valueNumber > 3 ? 'grabbing' : 'auto'}`,
+                          cursor: `${valueNumber > 3 ? 'grabbing' : 'pointer'}`,
+                          overflow: `${valueNumber > 3 ? 'hidden' : 'visible'}`,
                         }}
                       >
                         {cell.render('Cell')}


### PR DESCRIPTION
Hovering on the table samples invokes a small modal to show the whole content without truncation.
It works only in datasets with a typical sample set (father, mother, proband)