### PR TITLE
fix(FOROME-941): app crush with dataset loading

### DIFF
--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -245,6 +245,7 @@ export const en = {
     viewReturnedVariants: 'View returned variants',
     showReturnedVariantsForStep: 'Show {returnValue} variants for step {index}',
     dtreeDeleteConfirmation: 'Do you really want to delete this tree?',
+    inactiveField: 'Inactive field',
   },
   error: {
     getBack: 'Back to home',

--- a/src/pages/filter/dtree/components/query-builder/ui/inactive-field-label.tsx
+++ b/src/pages/filter/dtree/components/query-builder/ui/inactive-field-label.tsx
@@ -1,0 +1,38 @@
+import { observer } from 'mobx-react-lite'
+
+import { t } from '@i18n'
+import { Icon } from '@ui/icon'
+import { deleteAttribute } from '@utils/changeAttribute/deleteAttribute'
+import activeStepStore, { ActiveStepOptions } from '../../active-step.store'
+
+interface IInactiveFieldProps {
+  stepIndex: number
+  groupIndex: number
+}
+
+export const InactiveFieldLabel = observer(
+  ({ stepIndex, groupIndex }: IInactiveFieldProps) => {
+    const handleDeleteAttribute = () => {
+      activeStepStore.makeStepActive(
+        stepIndex,
+        ActiveStepOptions.StartedVariants,
+      )
+
+      deleteAttribute(groupIndex)
+    }
+    return (
+      <div className="flex items-center border border-red-secondary rounded-md px-1 py-px">
+        <span className="ml-1 text-12 leading-5 font-normal text-red-secondary">
+          {t('dtree.inactiveField')}
+        </span>
+
+        <Icon
+          name="Close"
+          size={14}
+          className="ml-1 cursor-pointer text-red-secondary"
+          onClick={handleDeleteAttribute}
+        />
+      </div>
+    )
+  },
+)

--- a/src/pages/filter/dtree/components/query-builder/ui/next-step-content-item.tsx
+++ b/src/pages/filter/dtree/components/query-builder/ui/next-step-content-item.tsx
@@ -21,6 +21,7 @@ import { getNumericExpression } from '@utils/getNumericExpression'
 import modalFiltersStore from '../../modals/components/modal-enum/modal-enum.store'
 import modalsVisibilityStore from '../../modals/modals-visibility-store'
 import { DropDownJoin } from './dropdown-join'
+import { InactiveFieldLabel } from './inactive-field-label'
 
 const ContentControl = styled.div`
   display: flex;
@@ -74,13 +75,15 @@ export const NextStepContentItem = observer(
     // }
     const [isVisible, setIsVisible] = useState(false)
     const limitSize = 3
+    const stepType = group[0]
+    const groupName = group[1]
 
-    const array = group.find((elem: any) => Array.isArray(elem))
+    const stepCondition = group.find(Array.isArray)
 
     const getButtonMessage = () => {
-      if (group[0] === StepTypeEnum.Numeric) return ''
+      if (stepType === StepTypeEnum.Numeric) return ''
 
-      const size = array.length - limitSize
+      const size = stepCondition.length - limitSize
 
       return expanded ? `Hide ${size} variants` : `Show ${size} variants`
     }
@@ -180,12 +183,16 @@ export const NextStepContentItem = observer(
               {group.includes(StepTypeEnum.Func) && (
                 <FnLabel currentStep={currentStep} className="shadow-dark" />
               )}
-              {`${group[1]}`}
+              {groupName || (
+                <InactiveFieldLabel stepIndex={index} groupIndex={currNo} />
+              )}
             </div>
+
             {/* TODO: add switch to step after implementation in backend */}
             {/* <div className="pt-1.5">
               <Switch isChecked={isChecked} onChange={toggleChecked} />
             </div> */}
+
             {!isNumeric && (
               <Checkbox
                 checked={isNotMode}
@@ -211,17 +218,16 @@ export const NextStepContentItem = observer(
             )}
 
             <div className="flex flex-col text-14 font-normal h-full flex-wrap mt-1">
-              {group[0] === StepTypeEnum.Numeric &&
-                getNumericExpression(array, group[1])}
+              {stepType === StepTypeEnum.Numeric &&
+                getNumericExpression(stepCondition, groupName)}
 
-              {group[0] !== StepTypeEnum.Numeric &&
-                array
-                  .slice(0, expanded ? Number.MAX_SAFE_INTEGER : limitSize)
+              {stepType !== StepTypeEnum.Numeric &&
+                stepCondition
+                  ?.slice(0, expanded ? Number.MAX_SAFE_INTEGER : limitSize)
                   .map((item: any[]) => <div key={Math.random()}>{item}</div>)}
 
-              {group[0] !== StepTypeEnum.Numeric && array.length > 3 && (
+              {stepType !== StepTypeEnum.Numeric && stepCondition?.length > 3 && (
                 <div
-                  key={Math.random()}
                   className="text-blue-bright cursor-pointer"
                   onClick={setExpandOnClick}
                 >

--- a/src/utils/changeAttribute/deleteAttribute.ts
+++ b/src/utils/changeAttribute/deleteAttribute.ts
@@ -3,7 +3,7 @@ import dtreeStore from '@store/dtree'
 import activeStepStore from '@pages/filter/dtree/components/active-step.store'
 import modalsControlStore from '@pages/filter/dtree/components/modals/modals-control-store'
 
-export const deleteAttribute = (): void => {
+export const deleteAttribute = (groupIndexToChange?: number): void => {
   const code = dtreeStore.dtreeCode ?? 'return False'
 
   const body = new URLSearchParams({
@@ -19,9 +19,21 @@ export const deleteAttribute = (): void => {
 
   const hasOneAttribute =
     dtreeStore.stepData[activeStepIndex].groups.length === 1
+
   const action = hasOneAttribute ? 'POINT' : 'ATOM'
 
-  const currentLocation = hasOneAttribute ? indexForApi : location
+  let currentLocation
+
+  const isInvalidAttribute =
+    groupIndexToChange &&
+    typeof groupIndexToChange === 'number' &&
+    action === 'ATOM'
+
+  if (isInvalidAttribute) {
+    currentLocation = [indexForApi, groupIndexToChange]
+  } else {
+    currentLocation = hasOneAttribute ? indexForApi : location
+  }
 
   body.append('instr', JSON.stringify([action, 'DELETE', currentLocation]))
 


### PR DESCRIPTION
https://quantori.atlassian.net/browse/FOROME-941

Added inactive field label just like on https://anfisa.forome.dev/app/dir
Steps to reproduce:
1. Open https://anfisa.forome.dev/app/dtree?ds=NOTCH2
2. Load BGM Research tree
3. Look at the first step
It has a close icon which means this step is inactive

This solution allows us to avoid adding additional filters for stepData and comments blocks. Besides, the structure of the applied tree will be the same for other datasets.