### PR TITLE
fix(FOROME-00): hotfix for table opening

### DIFF
--- a/src/store/ws/main-table.store.ts
+++ b/src/store/ws/main-table.store.ts
@@ -225,7 +225,6 @@ export class MainTable {
 
   resetData() {
     this.variantsAmount = 0
-    this.tabReport = []
   }
 }
 


### PR DESCRIPTION
There was resetting data for tab_report data in the main-page component that led to conflict with the new async architecture.