### PR TITLE
feat(FOROME-1367): made create derived dataset button disabled on empty conditions or too much variants exist

### DIFF
--- a/src/pages/filter/common/filter-control/filter-control.interface.tsx
+++ b/src/pages/filter/common/filter-control/filter-control.interface.tsx
@@ -9,7 +9,7 @@ export interface IFilterControlProps {
   isForwardAllowed: boolean
   isBackwardAllowed: boolean
   isEntryCreationAllowed: boolean
-  countOfVariants: number
+  disabledCreateDataset: boolean
   pageName: FilterControlOptionsNames
   goForward: () => void
   goBackward: () => void

--- a/src/pages/filter/common/filter-control/filter-control.interface.tsx
+++ b/src/pages/filter/common/filter-control/filter-control.interface.tsx
@@ -9,6 +9,7 @@ export interface IFilterControlProps {
   isForwardAllowed: boolean
   isBackwardAllowed: boolean
   isEntryCreationAllowed: boolean
+  countOfVariants: number
   pageName: FilterControlOptionsNames
   goForward: () => void
   goBackward: () => void

--- a/src/pages/filter/common/filter-control/filter-control.tsx
+++ b/src/pages/filter/common/filter-control/filter-control.tsx
@@ -27,7 +27,7 @@ import { IFilterControlProps } from './filter-control.interface'
 import { SolutionSelect } from './solution-select'
 
 //TODO - we need to receive this number from backend
-const XL_COUNT_OF_VARIANTS = 9000
+export const XL_COUNT_OF_VARIANTS = 9000
 
 export const FilterControl = observer(
   ({
@@ -39,7 +39,7 @@ export const FilterControl = observer(
     isForwardAllowed,
     isEntryCreationAllowed,
     isBackwardAllowed,
-    countOfVariants,
+    disabledCreateDataset,
     pageName,
     goForward,
     goBackward,
@@ -86,9 +86,6 @@ export const FilterControl = observer(
       filterStore.clearConditions()
     }
 
-    const createDisabled =
-      !filterStore.isFilterTouched || countOfVariants > XL_COUNT_OF_VARIANTS
-
     return (
       <div
         className={cn(
@@ -130,7 +127,7 @@ export const FilterControl = observer(
 
             <Divider orientation="vertical" className="h-[75%]" />
 
-            <CreateDataset disabled={createDisabled} />
+            <CreateDataset disabled={disabledCreateDataset} />
           </div>
 
           <div className="flex items-center">

--- a/src/pages/filter/common/filter-control/filter-control.tsx
+++ b/src/pages/filter/common/filter-control/filter-control.tsx
@@ -36,6 +36,7 @@ export const FilterControl = observer(
     isForwardAllowed,
     isEntryCreationAllowed,
     isBackwardAllowed,
+    countOfVariants,
     pageName,
     goForward,
     goBackward,
@@ -82,6 +83,9 @@ export const FilterControl = observer(
       filterStore.clearConditions()
     }
 
+    const createDisabled =
+      !filterStore.isFilterTouched || countOfVariants > 9000
+
     return (
       <div
         className={cn(
@@ -123,7 +127,7 @@ export const FilterControl = observer(
 
             <Divider orientation="vertical" className="h-[75%]" />
 
-            <CreateDataset />
+            <CreateDataset disabled={createDisabled} />
           </div>
 
           <div className="flex items-center">

--- a/src/pages/filter/common/filter-control/filter-control.tsx
+++ b/src/pages/filter/common/filter-control/filter-control.tsx
@@ -26,6 +26,9 @@ import {
 import { IFilterControlProps } from './filter-control.interface'
 import { SolutionSelect } from './solution-select'
 
+//TODO - we need to receive this number from backend
+const XL_COUNT_OF_VARIANTS = 9000
+
 export const FilterControl = observer(
   ({
     SolutionControl,
@@ -84,7 +87,7 @@ export const FilterControl = observer(
     }
 
     const createDisabled =
-      !filterStore.isFilterTouched || countOfVariants > 9000
+      !filterStore.isFilterTouched || countOfVariants > XL_COUNT_OF_VARIANTS
 
     return (
       <div

--- a/src/pages/filter/dtree/dtree.page.tsx
+++ b/src/pages/filter/dtree/dtree.page.tsx
@@ -13,7 +13,10 @@ import filterDtreesStore from '@store/filter-dtrees'
 import { Header } from '@components/header'
 import { VariantsCount } from '@components/variants-count'
 import { GlbPagesNames } from '@glb/glb-names'
-import { FilterControl } from '../common/filter-control/filter-control'
+import {
+  FilterControl,
+  XL_COUNT_OF_VARIANTS,
+} from '../common/filter-control/filter-control'
 import { FilterControlOptionsNames } from '../common/filter-control/filter-control.const'
 import { SolutionControlDtree } from './components/control-panel/solution-control-dtree'
 import { TextEditorButton } from './components/control-panel/text-editor-button'
@@ -112,12 +115,16 @@ export const DtreePage = observer((): ReactElement => {
         </Header>
 
         <FilterControl
+          disabledCreateDataset={
+            dtreeStore.dtreeStepIndices.length === 0 ||
+            !dtreeStore.totalFilteredCounts ||
+            dtreeStore.totalFilteredCounts.accepted > XL_COUNT_OF_VARIANTS
+          }
           pageName={FilterControlOptionsNames[GlbPagesNames.Dtree]}
           SolutionControl={SolutionControlDtree}
           createSolutionEntry={createDtree}
           availableSolutionEntries={availableSolutionEntries}
           isEntryCreationAllowed={isEntryCreationAllowed}
-          countOfVariants={getFiltersValue('all') || 0}
           isBackwardAllowed={dtreeStore.actionHistory.isBackwardAllowed}
           isForwardAllowed={dtreeStore.actionHistory.isForwardAllowed}
           goForward={dtreeStore.actionHistory.goForward}

--- a/src/pages/filter/dtree/dtree.page.tsx
+++ b/src/pages/filter/dtree/dtree.page.tsx
@@ -117,6 +117,7 @@ export const DtreePage = observer((): ReactElement => {
           createSolutionEntry={createDtree}
           availableSolutionEntries={availableSolutionEntries}
           isEntryCreationAllowed={isEntryCreationAllowed}
+          countOfVariants={getFiltersValue('all') || 0}
           isBackwardAllowed={dtreeStore.actionHistory.isBackwardAllowed}
           isForwardAllowed={dtreeStore.actionHistory.isForwardAllowed}
           goForward={dtreeStore.actionHistory.goForward}

--- a/src/pages/filter/refiner/refiner.page.tsx
+++ b/src/pages/filter/refiner/refiner.page.tsx
@@ -13,7 +13,10 @@ import { ExportReport } from '@components/export-report'
 import { Header } from '@components/header'
 import { VariantsCount } from '@components/variants-count'
 import { GlbPagesNames } from '@glb/glb-names'
-import { FilterControl } from '@pages/filter/common/filter-control/filter-control'
+import {
+  FilterControl,
+  XL_COUNT_OF_VARIANTS,
+} from '@pages/filter/common/filter-control/filter-control'
 import { IgvModal } from '@pages/filter/dtree/components/modals/components/igv'
 import { FilterRefiner } from '@pages/filter/refiner/components/filter-refiner'
 import { FilterControlOptionsNames } from '../common/filter-control/filter-control.const'
@@ -33,6 +36,8 @@ export const RefinerPage = observer((): ReactElement => {
   const createPreset = (presetName: string): void => {
     filterPresetsStore.createPreset(presetName, filterStore.conditions)
   }
+
+  const filterCounts = filterStore.stat.filteredCounts
 
   const modifiedPreset = filterStore.isPresetModified
     ? filterPresetsStore.activePreset
@@ -71,12 +76,16 @@ export const RefinerPage = observer((): ReactElement => {
       <FilterControl
         pageName={FilterControlOptionsNames[GlbPagesNames.Refiner]}
         SolutionControl={SolutionControlRefiner}
-        countOfVariants={allVariants || 0}
         createSolutionEntry={createPreset}
         availableSolutionEntries={availableSolutionEntries}
         isBackwardAllowed={filterStore.actionHistory.isBackwardAllowed}
         isForwardAllowed={filterStore.actionHistory.isForwardAllowed}
         isEntryCreationAllowed={isEntryCreationAllowed}
+        disabledCreateDataset={
+          filterStore.conditions.length === 0 ||
+          !filterCounts ||
+          filterCounts.variants > XL_COUNT_OF_VARIANTS
+        }
         goForward={filterStore.actionHistory.goForward}
         goBackward={filterStore.actionHistory.goBackward}
         className={styles.refinerPage__controls}

--- a/src/pages/filter/refiner/refiner.page.tsx
+++ b/src/pages/filter/refiner/refiner.page.tsx
@@ -42,6 +42,10 @@ export const RefinerPage = observer((): ReactElement => {
     ? modifiedPreset === activePreset
     : !filterStore.isConditionsEmpty
 
+  const allVariants = isXL
+    ? toJS(datasetStore.dsInfoData?.total)
+    : variantCounts
+
   useDatasetName()
 
   filterPresetsStore.observeHistory.useHook()
@@ -54,9 +58,7 @@ export const RefinerPage = observer((): ReactElement => {
     <div className={styles.refinerPage}>
       <Header className={styles.refinerPage__header}>
         <VariantsCount
-          variantCounts={
-            isXL ? toJS(datasetStore.dsInfoData?.total) : variantCounts
-          }
+          variantCounts={allVariants}
           transcriptsCounts={transcriptsCounts}
           dnaVariantsCounts={dnaVariantsCounts}
           showDnaVariants={!isXL}
@@ -69,6 +71,7 @@ export const RefinerPage = observer((): ReactElement => {
       <FilterControl
         pageName={FilterControlOptionsNames[GlbPagesNames.Refiner]}
         SolutionControl={SolutionControlRefiner}
+        countOfVariants={allVariants || 0}
         createSolutionEntry={createPreset}
         availableSolutionEntries={availableSolutionEntries}
         isBackwardAllowed={filterStore.actionHistory.isBackwardAllowed}

--- a/src/pages/ws/ui/control-panel/control-panel.tsx
+++ b/src/pages/ws/ui/control-panel/control-panel.tsx
@@ -2,6 +2,7 @@ import styles from './control-panel.module.css'
 
 import { ReactElement } from 'react'
 
+import dtreeStore from '@store/dtree'
 import filterStore from '@store/filter'
 import { Divider } from '@ui/divider'
 import { CreateDataset } from './create-dataset'
@@ -40,7 +41,12 @@ export const ControlPanel = (): ReactElement => (
     </div>
 
     <div className={styles.controlPanel__save}>
-      <CreateDataset disabled={!filterStore.isFilterTouched} />
+      <CreateDataset
+        disabled={
+          filterStore.conditions.length === 0 &&
+          dtreeStore.dtreeStepIndices.length === 0
+        }
+      />
     </div>
   </div>
 )

--- a/src/pages/ws/ui/control-panel/control-panel.tsx
+++ b/src/pages/ws/ui/control-panel/control-panel.tsx
@@ -1,6 +1,7 @@
 import styles from './control-panel.module.css'
 
 import { ReactElement } from 'react'
+import { observer } from 'mobx-react-lite'
 
 import dtreeStore from '@store/dtree'
 import filterStore from '@store/filter'
@@ -14,39 +15,41 @@ import { GenesZone } from './zones/genes-zone'
 import { SamplesZone } from './zones/samples-zone'
 import { TagsZone } from './zones/tags-zone'
 
-export const ControlPanel = (): ReactElement => (
-  <div className={styles.controlPanel}>
-    <div className={styles.controlPanel__controls}>
-      <SelectPreset />
+export const ControlPanel = observer((): ReactElement => {
+  return (
+    <div className={styles.controlPanel}>
+      <div className={styles.controlPanel__controls}>
+        <SelectPreset />
 
-      <Divider orientation="vertical" />
+        <Divider orientation="vertical" />
 
-      <EditFilter />
+        <EditFilter />
 
-      <Divider orientation="vertical" />
+        <Divider orientation="vertical" />
 
-      <CustomizeTable />
+        <CustomizeTable />
 
-      <Divider orientation="vertical" />
+        <Divider orientation="vertical" />
 
-      <div className={styles.controlPanel__zones}>
-        <GenesZone />
+        <div className={styles.controlPanel__zones}>
+          <GenesZone />
 
-        <GenesListZone />
+          <GenesListZone />
 
-        <SamplesZone />
+          <SamplesZone />
 
-        <TagsZone />
+          <TagsZone />
+        </div>
+      </div>
+
+      <div className={styles.controlPanel__save}>
+        <CreateDataset
+          disabled={
+            filterStore.conditions.length === 0 &&
+            dtreeStore.dtreeStepIndices.length === 0
+          }
+        />
       </div>
     </div>
-
-    <div className={styles.controlPanel__save}>
-      <CreateDataset
-        disabled={
-          filterStore.conditions.length === 0 &&
-          dtreeStore.dtreeStepIndices.length === 0
-        }
-      />
-    </div>
-  </div>
-)
+  )
+})

--- a/src/pages/ws/ui/control-panel/control-panel.tsx
+++ b/src/pages/ws/ui/control-panel/control-panel.tsx
@@ -2,6 +2,7 @@ import styles from './control-panel.module.css'
 
 import { ReactElement } from 'react'
 
+import filterStore from '@store/filter'
 import { Divider } from '@ui/divider'
 import { CreateDataset } from './create-dataset'
 import { CustomizeTable } from './customize-table'
@@ -39,7 +40,7 @@ export const ControlPanel = (): ReactElement => (
     </div>
 
     <div className={styles.controlPanel__save}>
-      <CreateDataset />
+      <CreateDataset disabled={!filterStore.isFilterTouched} />
     </div>
   </div>
 )

--- a/src/pages/ws/ui/control-panel/create-dataset.tsx
+++ b/src/pages/ws/ui/control-panel/create-dataset.tsx
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { FC } from 'react'
 
 import { useModal } from '@core/hooks/use-modal'
 import { t } from '@i18n'
@@ -6,7 +6,11 @@ import { Button } from '@ui/button'
 import { DecisionTreesMenuDataCy } from '@data-testid'
 import { CreateDatasetDialog } from '@pages/filter/dtree/components/modals/components/create-dataset-dialog'
 
-export const CreateDataset = (): ReactElement => {
+interface ICreateDatasetProps {
+  disabled?: boolean
+}
+
+export const CreateDataset: FC<ICreateDatasetProps> = ({ disabled }) => {
   const [creationDialog, openCreationDialog, closeCreationDialog] = useModal()
   const { isOpen } = creationDialog
 
@@ -15,6 +19,8 @@ export const CreateDataset = (): ReactElement => {
       <Button
         text={t('dsCreation.createDerivedDS')}
         onClick={openCreationDialog}
+        disabled={disabled}
+        variant="primary-dark"
         dataTestId={DecisionTreesMenuDataCy.saveDataset}
       />
 

--- a/src/ui/button/button.module.css
+++ b/src/ui/button/button.module.css
@@ -67,6 +67,7 @@
     &:disabled {
       background-color: theme("colors.blue.lighter");
       border-color: theme("colors.blue.lighter");
+      color: theme("colors.blue.dark");
     }
   }
 


### PR DESCRIPTION
[Task](https://quantori.atlassian.net/browse/FOROME-1367)
In ControlPanel we check only filters, because it is used only in ws page, which can be opened only if we have less than 3000 variants.