### PR TITLE
fix(FOROME-1381): FR inheritance mode edition

### DIFF
--- a/src/store/filter/filter-stat-func.store.ts
+++ b/src/store/filter/filter-stat-func.store.ts
@@ -16,17 +16,7 @@ export class FilterStatFuncStore extends BaseStatFuncStore<
   }
 
   protected fetch(query: IStatFuncQuery): Promise<IStatFunc> {
-    let conditions = filterStore.conditions
-
-    if (
-      filterStore.selectedConditionIndex >= 0 &&
-      filterStore.conditions[filterStore.selectedConditionIndex]
-    ) {
-      conditions = filterStore.conditions.slice(
-        0,
-        filterStore.selectedConditionIndex,
-      )
-    }
+    const conditions = filterStore.prevConditions || filterStore.conditions
 
     return filteringProvider
       .getStatFunc({

--- a/src/store/filter/filter-stat-func.store.ts
+++ b/src/store/filter/filter-stat-func.store.ts
@@ -16,10 +16,22 @@ export class FilterStatFuncStore extends BaseStatFuncStore<
   }
 
   protected fetch(query: IStatFuncQuery): Promise<IStatFunc> {
+    let conditions = filterStore.conditions
+
+    if (
+      filterStore.selectedConditionIndex >= 0 &&
+      filterStore.conditions[filterStore.selectedConditionIndex]
+    ) {
+      conditions = filterStore.conditions.slice(
+        0,
+        filterStore.selectedConditionIndex,
+      )
+    }
+
     return filteringProvider
       .getStatFunc({
         ds: datasetStore.datasetName,
-        conditions: filterStore.conditions,
+        conditions,
         rq_id: String(Date.now()),
         unit: query.unit,
         param: query.param,

--- a/src/store/filter/filter.store.ts
+++ b/src/store/filter/filter.store.ts
@@ -208,6 +208,17 @@ export class FilterStore {
     return undefined
   }
 
+  public get prevConditions(): TCondition[] | null {
+    if (
+      this.selectedConditionIndex >= 0 &&
+      this.conditions[this.selectedConditionIndex]
+    ) {
+      return this.conditions.slice(0, this.selectedConditionIndex)
+    }
+
+    return null
+  }
+
   public addCondition(condition: TCondition): number {
     this._conditions.push(condition)
 


### PR DESCRIPTION
https://quantori.atlassian.net/browse/FOROME-1381
The point is when you open the FR func attribute in redactor mode you need to send prev conditions data in order to get actual func data for redaction. This feature was already implemented for enum and numeric attrs.
Besides, this feature resolved this [issue](https://quantori.atlassian.net/browse/FOROME-1382) too. So, please check it.