### PR TITLE
feat(FOROME-1572): add showing preset kind to remove collisions

### DIFF
--- a/src/components/solution-control/solution-create-dialog/solution-create-dialog.tsx
+++ b/src/components/solution-control/solution-create-dialog/solution-create-dialog.tsx
@@ -86,6 +86,7 @@ export const SolutionCreateDialog = ({
           controlName,
         })}
         onChange={event => setSolutionName(event.target.value)}
+        error={hasError ? errorText : undefined}
       />
 
       <div className="flex flex-col mt-[16px] text-12">
@@ -99,10 +100,6 @@ export const SolutionCreateDialog = ({
           resetText="Choose the type"
         />
       </div>
-
-      {hasError && (
-        <div className="text-red-secondary text-12">{errorText}</div>
-      )}
     </Dialog>
   )
 }

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -154,6 +154,7 @@ export const en = {
       candidateName: 'Candidate set name',
       whatsNext: "What's next?",
       relevantPresets: 'Relevant presets',
+      presetNameWithKind: '{ name } (kind: { kind })',
       additionalPresetFilter: 'Additional preset filters',
       notApplicableForXl: 'Not applicable for XL dataset',
       simpleFilter: 'Simple Filter',

--- a/src/pages/filter/dtree/components/dtree-units-list.tsx
+++ b/src/pages/filter/dtree/components/dtree-units-list.tsx
@@ -9,7 +9,6 @@ import dtreeStore from '@store/dtree'
 import stepStore from '@store/dtree/step.store'
 import { UnitsList } from '@components/units-list'
 import { DecisionTreesResultsDataCy } from '@data-testid'
-import { GlbPagesNames } from '@glb/glb-names'
 import modalsVisibilityStore from '@pages/filter/dtree/components/modals/modals-visibility-store'
 import { AttributeKinds, TPropertyStatus } from '@service-providers/common'
 

--- a/src/pages/filter/dtree/components/modals/components/create-dataset-dialog.tsx
+++ b/src/pages/filter/dtree/components/modals/components/create-dataset-dialog.tsx
@@ -80,12 +80,6 @@ export const CreateDatasetDialog = observer(
     }, [isOpen, pathName])
 
     const saveDatasetAsync = async () => {
-      if (toJS(dirinfoStore.dsDistKeys).includes(value)) {
-        setError(DatasetCreationErrorsEnum.DatasetExists)
-
-        return
-      }
-
       const result = await operations.saveDatasetAsync(value, pathName)
 
       if (!result.ok && result.message) {
@@ -144,12 +138,16 @@ export const CreateDatasetDialog = observer(
       }
 
       if (
-        noSymbolPattern.test(name) ||
-        noFirstNumberPattern.test(name) ||
-        noSpacesPattern.test(name) ||
-        name.length > 250
+        noSymbolPattern.test(value) ||
+        noFirstNumberPattern.test(value) ||
+        noSpacesPattern.test(value) ||
+        value.length > 250
       ) {
         setError(DatasetCreationErrorsEnum.IncorrectName)
+      } else if (
+        toJS(dirinfoStore.dsDistKeys).some(dsName => dsName === name)
+      ) {
+        setError(DatasetCreationErrorsEnum.DatasetExists)
       } else {
         setError('')
       }
@@ -173,18 +171,15 @@ export const CreateDatasetDialog = observer(
         width="s"
       >
         <div className="flex flex-col">
-          <div>
-            <div className="mt-1">
-              <Input
-                disabled={!operations.isCreationOver}
-                value={value}
-                label={t('dsCreation.label')}
-                onChange={e => handleChange(e.target.value)}
-                dataTestId={DecisionTreesMenuDataCy.datasetNameInput}
-              />
-            </div>
-
-            <span className="text-12 text-red-secondary mt-2">{error}</span>
+          <div className="mt-1">
+            <Input
+              disabled={!operations.isCreationOver}
+              value={value}
+              label={t('dsCreation.label')}
+              onChange={e => handleChange(e.target.value)}
+              error={error}
+              dataTestId={DecisionTreesMenuDataCy.datasetNameInput}
+            />
           </div>
 
           {!isDone && pathName === PatnNameEnum.Ws && (


### PR DESCRIPTION
[Task](https://quantori.atlassian.net/browse/FOROME-1572)
As back end accepts dtrees and presets with same name for dataset and as it is different entities, it seems wrong to restrict this for user. To resolve bug I add checking kinds of preset on choosing and add showing type of preset if it has name collisions. 